### PR TITLE
Avoid metrics collection workers unless endpoint

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_collector_worker.rb
@@ -11,5 +11,14 @@ module ManageIQ::Providers
     def self.ems_class
       ManageIQ::Providers::Kubernetes::ContainerManager
     end
+
+    # Override PerEmsTypeWorkerMixin.emses_in_zone to limit metrics collection
+    def self.emses_in_zone
+      super.select do |ems|
+        ems.supports_metrics?.tap do |supported|
+          _log.info("Skipping [#{ems.name}] since it has no metrics endpoint") unless supported
+        end
+      end
+    end
   end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -14,6 +14,10 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     end
   end
 
+  def supports_metrics?
+    connection_configurations.hawkular != nil
+  end
+
   module ClassMethods
     def raw_api_endpoint(hostname, port, path = '')
       URI::HTTPS.build(:host => hostname, :port => port.presence.try(:to_i), :path => path)


### PR DESCRIPTION
Starting with k8s since container_manager_mixin is shared with openshift.
We will then need to do one of:
- copy emses_in_zone to openshift's metrics_collector_worker.rb
OR
- create a common component for both metrics collectors

supports_metrics? aims to be replaced by a support feature.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1437138#c0