### PR TITLE
kubernetes_connect: add timeout settings

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -31,7 +31,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
         options[:version] || kubernetes_version,
         :ssl_options    => Kubeclient::Client::DEFAULT_SSL_OPTIONS.merge(options[:ssl_options] || {}),
         :auth_options   => kubernetes_auth_options(options),
-        :http_proxy_uri => VMDB::Util.http_proxy_uri
+        :http_proxy_uri => VMDB::Util.http_proxy_uri,
+        :timeouts       => {
+          :open => Settings.ems.ems_kubernetes.open_timeout.to_f_with_method,
+          :read => Settings.ems.ems_kubernetes.read_timeout.to_f_with_method
+        }
       )
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,6 +36,8 @@
         :network:
           :critical:
             - POD_HOSTPORTCONFLICT
+    :open_timeout: 60.seconds
+    :read_timeout: 60.seconds
 :http_proxy:
   :kubernetes:
     :host:

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -112,7 +112,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       require 'kubeclient'
       expect(Kubeclient::Client).to receive(:new).with(
         instance_of(URI::HTTPS), 'v1',
-        hash_including(:http_proxy_uri => VMDB::Util.http_proxy_uri)
+        hash_including(:http_proxy_uri => VMDB::Util.http_proxy_uri,
+                       :timeouts       => match(:open => be > 0, :read => be > 0))
       )
       described_class.raw_connect(hostname, port, options)
     end


### PR DESCRIPTION
Ability to constrol kubeclient timeouts from settings.yml

openshift half: ~~https://github.com/ManageIQ/manageiq-providers-openshift/pull/8~~ unnecessary on master given https://github.com/ManageIQ/manageiq-providers-openshift/pull/7, but will add it in backports.

Tested:
- [x] [Exercised](https://github.com/abonas/kubeclient/pull/246#issuecomment-298221765) in rails console and refresh, events, SSA in manageiq, confirmed low enough values cause timeouts.
- [x] core manageiq tests passed locally with this, but I don't think they cover anything relevant.

https://bugzilla.redhat.com/show_bug.cgi?id=1440950
@miq-bot add-label euwe/yes, fine/yes (actually we plan a 5.7.1 hotfix but I suppose we also want normal backports, so customer uprading will not lose hotfix functionality?)

@moolitayer @agrare Please review.