### PR TITLE
Option needed for new ems_refresh.openshift.store_unused_images setting

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -1100,7 +1100,8 @@ module ManageIQ::Providers::Kubernetes
       res
     end
 
-    def parse_container_image(image, imageID)
+    # may return nil if store_new_images = false
+    def parse_container_image(image, imageID, store_new_images: true)
       container_image, container_image_registry = parse_image_name(image, imageID)
       host_port = nil
 
@@ -1124,6 +1125,7 @@ module ManageIQ::Providers::Kubernetes
         :container_image, :by_digest, container_image_identity)
 
       if stored_container_image.nil?
+        return nil unless store_new_images
         @data_index.store_path(
           :container_image, :by_digest,
           container_image_identity, container_image

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -658,6 +658,15 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         expect(first_obj).to be(second_obj)
       end
     end
+
+    it "returns existing image or nil with store_new_images=false" do
+      obj1 = parser.parse_container_image(shared_image_without_host, shared_ref)
+      obj2 = parser.parse_container_image(shared_image_without_host, shared_ref, :store_new_images => false)
+      obj3 = parser.parse_container_image(shared_image_without_host, unique_ref, :store_new_images => false)
+      expect(obj1).not_to be nil
+      expect(obj2).to be obj2
+      expect(obj3).to be nil
+    end
   end
 
   describe "cross_link_node" do


### PR DESCRIPTION
#kubernetes part of https://github.com/ManageIQ/manageiq/pull/14662 after repo split.
This will have to be merged before openshift part https://github.com/ManageIQ/manageiq-providers-openshift/pull/9.

Strawman alternative/baseline for https://github.com/ManageIQ/manageiq/pull/14628.
Will allow to still get_container_images=true, but instead of saving metadata (labels etc) on all images openshift gave us, save it only for images that have been mentioned by pods.

Here called `store_new_images` because this function doesn't have the context to understand which images are "used".
For `store_unused_images`=false setting, it'll be called twice:
- from parse_pods with true, adding all images
- from parse_openshift_image with false, only enriching previous images

cc @agrare @enoodle @zeari 
