### PR TITLE
Moving hawkular-client dependency from manageiq-gems-pending

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
+  s.add_runtime_dependency "hawkular-client", "~> 3.0.2"
+
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
Add runtime dependency on hawkular-client.