### PR TITLE
configurable timeout for SSA

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -264,6 +264,10 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     end
   end
 
+  def self.current_job_timeout(timeout_adjustment = 1)
+    ::Settings.container_scanning.scanning_job_timeout.to_f_with_method * timeout_adjustment
+  end
+
   private
 
   def ext_management_system

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,3 +9,5 @@
     :password:
     :port:
     :user:
+:container_scanning:
+  :scanning_job_timeout: 20.minutes

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -160,6 +160,15 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
       end
     end
 
+    context "#current_job_timeout" do
+      it "checks for timeout in Settings" do
+        stub_settings_merge(:container_scanning => {:scanning_job_timeout => '15.minutes'})
+        expect(@job.send(:current_job_timeout)).to eq(900)
+        stub_settings_merge(:container_scanning => {:scanning_job_timeout => 600})
+        expect(@job.send(:current_job_timeout)).to eq(600)
+      end
+    end
+
     it 'should add correct environment variables' do
       att_name = 'http_proxy'
       my_value = "MY_TEST_VALUE"


### PR DESCRIPTION
This adds an option to configure timeout for container ssa jobs:

- With the global settings file, under "container_scanning" in the field "scanning_job_timeout"

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1447672