### PR TITLE
Make recursive openstruct an explicit dependency

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "hawkular-client", "~> 3.0.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
+  s.add_development_dependency "recursive-open-struct",     "~> 1.0.0"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
Previously, we got this dependency implicitly through manageiq,
kubeclient, etc.  Since we use this heavily in tests here, we should
state our reliance on this gem.

Needed for: https://github.com/ManageIQ/manageiq/pull/15096