### PR TITLE
Provide a reverse lookup for provider entities

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/entities_mapping.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/entities_mapping.rb
@@ -22,4 +22,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EntitiesMapping
   def miq_entity(entity)
     MAPPING[entity]
   end
+
+  # NOTE: Use of this method may result in unexpected behavior.  If more than
+  # one ManageIQ class maps to an entity, this method will only return the first
+  # instance.  For example, ContainerProject maps to 'namespace' and 'project'.
+  # This method will only return 'namespace'
+  def entity_by_resource(entity)
+    MAPPING.key(entity)
+  end
 end


### PR DESCRIPTION
There are instances where are "reverse" lookup of entity mappings is desirable.  This is needed for pull requests:

https://github.com/ManageIQ/manageiq/pull/14798
https://github.com/ManageIQ/manageiq-providers-openshift/pull/2
https://github.com/ManageIQ/manageiq-automation_engine/pull/7
