### PR TITLE
Move image registered_on field to openshift provider

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -795,11 +795,10 @@ module ManageIQ::Providers::Kubernetes
 
       [
         {
-          :name          => image_parts[:name],
-          :tag           => image_parts[:tag],
-          :digest        => digest,
-          :image_ref     => image_ref,
-          :registered_on => Time.now.utc
+          :name      => image_parts[:name],
+          :tag       => image_parts[:tag],
+          :digest    => digest,
+          :image_ref => image_ref,
         },
         hostname && {
           :name => hostname,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -194,7 +194,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
       it "tests '#{ex[:image_name]}'" do
         result_image, result_registry = parser.send(:parse_image_name, ex[:image_name], ex[:image_ref])
 
-        expect(result_image.except(:registered_on)).to eq(ex[:image])
+        expect(result_image).to eq(ex[:image])
         expect(result_registry).to eq(ex[:registry])
       end
     end


### PR DESCRIPTION
**Deiscription**

We currently insert a wrong place-holder value to the `ContainerImage#registered_on` field `:registered_on => Time.now.utc`

This PR remove this place-holder value from the Kubernetes provider, and insert the correct value in a new PR in the OpenShift provider.

Issue: https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/17
Openshift PR: https://github.com/ManageIQ/manageiq-providers-openshift/pull/17 
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1454329