### PR TITLE
Set container scanning user

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -157,6 +157,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     target_class, target_id = target_class.class.name, target_class.id if target_class.kind_of?(ContainerImage)
     Job.create_job(
       "ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job",
+      :userid          => User.current_user.userid,
       :name            => "Container image analysis",
       :target_class    => target_class,
       :target_id       => target_id,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -79,26 +79,30 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
     context "#initialize" do
       it "Creates a new scan job" do
         image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
+        User.current_user = FactoryGirl.create(:user, :userid => "bob")
         job = @ems.raw_scan_job_create(image.class, image.id)
         expect(job).to have_attributes(
           :dispatch_status => "pending",
           :state           => "waiting_to_start",
           :status          => "ok",
           :message         => "process initiated",
-          :target_class    => "ContainerImage"
+          :target_class    => "ContainerImage",
+          :userid          => "bob"
         )
       end
 
       it "Is backward compatible with #13722" do
         # https://github.com/ManageIQ/manageiq/pull/13722
         image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
+        User.current_user = FactoryGirl.create(:user, :userid => "bob")
         job = @ems.raw_scan_job_create(image)
         expect(job).to have_attributes(
           :dispatch_status => "pending",
           :state           => "waiting_to_start",
           :status          => "ok",
           :message         => "process initiated",
-          :target_class    => "ContainerImage"
+          :target_class    => "ContainerImage",
+          :userid          => "bob"
         )
       end
     end
@@ -132,6 +136,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
         @job.signal(:data, '<summary><syncmetadata></syncmetadata></summary>')
       end
 
+      User.current_user = FactoryGirl.create(:user)
       @job = @ems.raw_scan_job_create(@image.class, @image.id)
       allow(MiqQueue).to receive(:put_unless_exists) do |args|
         @job.signal(*args[:args])

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -92,6 +92,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
 
     it ".scan_job_create" do
       image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
+      User.current_user = FactoryGirl.create(:user, :userid => "bob")
       job = @ems.raw_scan_job_create(image.class, image.id)
 
       expect(job.state).to eq("waiting_to_start")
@@ -100,6 +101,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       expect(job.target_id).to eq(image.id)
       expect(job.type).to eq(ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job.name)
       expect(job.zone).to eq("default")
+      expect(job.userid).to eq("bob")
     end
   end
 


### PR DESCRIPTION
Before this change the user displayed in `tasks-> All Tasks` was always system.
After the user should be the logged in user initiating the scan

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1439652