### PR TITLE
Add Dependency on image-inspector-client gem

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_runtime_dependency "hawkular-client", "~> 3.0.2"
+  s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "recursive-open-struct",     "~> 1.0.0"


### PR DESCRIPTION
Moving from https://github.com/ManageIQ/manageiq-gems-pending/blob/master/manageiq-gems-pending.gemspec 