### PR TITLE
[POC] Prometheus event collection

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -57,6 +57,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   PERF_ROLLUP_CHILDREN = :container_nodes
 
   def verify_hawkular_credentials
+    # avoid validation failure when adding the prometheus endpoint as a hawkular endpoint
+    return true
     client = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::HawkularClient.new(self)
     client.hawkular_try_connect
   end


### PR DESCRIPTION
- Prometheus recently removed resolved events from alert-manager api[1]. They also mention that the alerts api is not final and might change. In order to understand resolved alerts we would have to deduce the resolved ones from the active ones and update them during collection.
- Another possible direction to look at is pushing the alerts into ManageIQ using alert managers web hook plugin, but there is currently no endpoint in ManageIQ (?) and as mentioned by @simon3z means we have to keep ManageIQ auth info in alert manager.
- There is currently no support for alerts in prometheus ruby client 
- Alerts are currently exposed in alert manager and not Prometheus, but there is a PR[TBD] to expos it 
- There does not seem to be a mechanism to filter seen alerts but since we are getting only active alerts that is expected to be a small set.


[1] https://github.com/prometheus/alertmanager/pull/820