### PR TITLE
Using the new options for image-scanning options

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -14,6 +14,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
   require_nested :Scanning
 
   include ManageIQ::Providers::Kubernetes::ContainerManagerMixin
+  include ManageIQ::Providers::Kubernetes::ContainerManager::Options
 
   # See HasMonitoringManagerMixin
   has_one :monitoring_manager,

--- a/app/models/manageiq/providers/kubernetes/container_manager/options.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/options.rb
@@ -1,0 +1,75 @@
+module ManageIQ::Providers::Kubernetes::ContainerManager::Options
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def proxy_settings
+      {
+        :http_proxy => {
+          :label          => N_('HTTP Proxy'),
+          :help_text      => N_('HTTP Proxy to connect ManageIQ to the provider. example: http://user:password@my_https_proxy'),
+          :global_default => VMDB::Util.http_proxy_uri,
+        },
+      }
+    end
+
+    def advanced_settings
+      {
+        :image_inspector_options => {
+          :label     => N_('Image Inspector Options'),
+          :help_text => N_('Settings for Image Inspector tool'),
+          :settings  => {
+            :http_proxy  => {
+              :label     => N_('HTTP Proxy'),
+              :help_text => N_('HTTP Proxy to connect image inspector pods to the internet. example: http://user:password@my_https_proxy'),
+            },
+            :https_proxy => {
+              :label     => N_('HTTPS Proxy'),
+              :help_text => N_('HTTPS Proxy to connect image inspector pods to the internet. example: https://user:password@my_https_proxy'),
+            },
+            :no_proxy    => {
+              :label     => N_('NO Proxy'),
+              :help_text => N_('NO Proxy lists urls that should\'nt be sent to any proxy. example: my_file_server.org'),
+            },
+            :repository  => {
+              :label          => N_('Image-Inspector Repository'),
+              :help_text      => N_('Image-Inspector Repository. example: openshift/image-inspector'),
+              :global_default => Settings.ems.ems_kubernetes.image_inspector_repository,
+            },
+            :registry    => {
+              :label          => N_('Image-Inspector Registry'),
+              :help_text      => N_('Registry to provide the image inspector repository. example: docker.io'),
+              :global_default => Settings.ems.ems_kubernetes.image_inspector_registry,
+            },
+            :image_tag   => {
+              :label          => N_('Image-Inspector Tag'),
+              :help_text      => N_('Image-Inspector image tag. example: 2.1'),
+              :global_default => ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job::INSPECTOR_IMAGE_TAG,
+            },
+            :cve_url     => {
+              :label     => N_('CVE location'),
+              :help_text => N_('Enables defining a URL path prefix for XCCDF file instead of accessing the default location.
+  example: http://my_file_server.org:3333/xccdf_files/
+  Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
+              # Future versions of image inspector will extend this.
+            },
+          }
+        }
+      }
+    end
+
+    def provider_settings
+      {
+        :proxy_settings    => {
+          :label     => N_('Proxy Settings'),
+          :help_text => N_('Proxy Settings for connection to the provider'),
+          :settings  => proxy_settings,
+        },
+        :advanced_settings => {
+          :label     => N_('Advanced Settings'),
+          :help_text => N_('Advanced Settings for provider configuration'),
+          :settings  => advanced_settings,
+        }
+      }
+    end
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -42,7 +42,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
         options[:version] || kubernetes_version,
         :ssl_options    => Kubeclient::Client::DEFAULT_SSL_OPTIONS.merge(options[:ssl_options] || {}),
         :auth_options   => kubernetes_auth_options(options),
-        :http_proxy_uri => VMDB::Util.http_proxy_uri,
+        :http_proxy_uri => options[:http_proxy] || VMDB::Util.http_proxy_uri,
         :timeouts       => {
           :open => Settings.ems.ems_kubernetes.open_timeout.to_f_with_method,
           :read => Settings.ems.ems_kubernetes.read_timeout.to_f_with_method
@@ -108,11 +108,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
   def connect(options = {})
     effective_options = options.merge(
-      :hostname => options[:hostname] || address,
-      :port     => options[:port] || port,
-      :user     => options[:user] || authentication_userid(options[:auth_type]),
-      :pass     => options[:pass] || authentication_password(options[:auth_type]),
-      :bearer   => options[:bearer] || authentication_token(options[:auth_type] || 'bearer'),
+      :hostname    => options[:hostname] || address,
+      :port        => options[:port] || port,
+      :user        => options[:user] || authentication_userid(options[:auth_type]),
+      :pass        => options[:pass] || authentication_password(options[:auth_type]),
+      :bearer      => options[:bearer] || authentication_token(options[:auth_type] || 'bearer'),
+      :http_proxy  => self.options ? self.options.fetch_path(:proxy_settings, :http_proxy) : nil,
       :ssl_options => options[:ssl_options] || {
         :verify_ssl => verify_ssl_mode,
         :cert_store => ssl_cert_store


### PR DESCRIPTION
Based on https://github.com/ManageIQ/manageiq/pull/15398

This will use the options field for per-provider configuration in image scanning.
Also, This will try to use the http_proxy set in the options to connect to the provider instead of the one defined in the settings file. Originally it was planned to have `https_proxy` and `no_proxy` options as well for the connection to the provider but as they are not used currently I left them out. 