### PR TITLE
Separate data_index lookups from parsing

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -532,19 +532,10 @@ module ManageIQ::Providers::Kubernetes
       if new_result[:ems_ref].nil? # Typically this happens for kubernetes services
         new_result[:ems_ref] = "#{new_result[:namespace]}_#{new_result[:name]}"
       end
-      container_groups = []
 
-      endpoint_container_groups = @data_index.fetch_path(
+      container_groups = @data_index.fetch_path(
         :container_endpoints, :by_namespace_and_name, new_result[:namespace],
         new_result[:name], :container_groups)
-      endpoint_container_groups ||= []
-
-      endpoint_container_groups.each do |group|
-        cg = @data_index.fetch_path(
-          path_for_entity("pod"), :by_namespace_and_name, group[:namespace],
-          group[:name])
-        container_groups << cg unless cg.nil?
-      end
 
       labels = parse_labels(service)
       new_result.merge!(

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -59,6 +59,7 @@ module ManageIQ::Providers::Kubernetes
       key = path_for_entity("node")
       process_collection(inventory["node"], key) { |n| parse_node(n) }
       @data[key].each do |cn|
+        cn[:additional_attributes] = @data_index.fetch_path(:additional_attributes, :by_node, cn[:name])
         @data_index.store_path(key, :by_name, cn[:name], cn)
       end
     end
@@ -522,8 +523,6 @@ module ManageIQ::Providers::Kubernetes
 
       new_result[:container_conditions] = parse_conditions(node)
       cross_link_node(new_result)
-
-      new_result[:additional_attributes] = @data_index.fetch_path(:additional_attributes, :by_node, node.metadata.name)
 
       new_result
     end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -948,32 +948,14 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
       }
       parser.get_additional_attributes(inventory)
       parser.get_nodes(inventory)
-      expect(parser.instance_variable_get(:@data)[:container_nodes]).to eq([{
-        :name                  => 'test-node',
-        :ems_ref               => 'f0c1fe7e-9c09-11e5-bb22-28d2447dcefe',
-        :ems_created_on        => '2016-01-01T11:10:21Z',
-        :container_conditions  => [],
-        :identity_infra        => 'aws:///zone/aws-id',
-        :labels                => [],
-        :tags                  => [],
-        :lives_on_id           => nil,
-        :lives_on_type         => nil,
-        :max_container_groups  => nil,
-        :computer_system       => {
-          :hardware         => {
-            :cpu_total_cores => nil,
-            :memory_mb       => nil
-          },
-          :operating_system => {
-            :distribution   => nil,
-            :kernel_version => nil
-          }
-        },
-        :namespace             => nil,
-        :resource_version      => '369104',
-        :type                  => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
-        :additional_attributes => [{ :name => "key", :value => "val", :section => "additional_attributes" }]
-      }])
+      expect(parser.instance_variable_get(:@data)[:container_nodes]).to match(
+        [
+          a_hash_including(
+            :name                  => 'test-node',
+            :additional_attributes => [{ :name => "key", :value => "val", :section => "additional_attributes" }]
+          )
+        ]
+      )
     end
 
     it "handles node with multiple custom attributes" do
@@ -984,33 +966,15 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
       }
       parser.get_additional_attributes(inventory)
       parser.get_nodes(inventory)
-      expect(parser.instance_variable_get(:@data)[:container_nodes]).to eq([{
-        :name                  => 'test-node',
-        :ems_ref               => 'f0c1fe7e-9c09-11e5-bb22-28d2447dcefe',
-        :ems_created_on        => '2016-01-01T11:10:21Z',
-        :container_conditions  => [],
-        :identity_infra        => 'aws:///zone/aws-id',
-        :labels                => [],
-        :tags                  => [],
-        :lives_on_id           => nil,
-        :lives_on_type         => nil,
-        :max_container_groups  => nil,
-        :computer_system       => {
-          :hardware         => {
-            :cpu_total_cores => nil,
-            :memory_mb       => nil
-          },
-          :operating_system => {
-            :distribution   => nil,
-            :kernel_version => nil
-          }
-        },
-        :namespace             => nil,
-        :resource_version      => '369104',
-        :type                  => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
-        :additional_attributes => [{ :name => "key1", :value => "val1", :section => "additional_attributes" },
-                                   { :name => "key2", :value => "val2", :section => "additional_attributes" }]
-      }])
+      expect(parser.instance_variable_get(:@data)[:container_nodes]).to match(
+        [
+          a_hash_including(
+            :name                  => 'test-node',
+            :additional_attributes => [{ :name => "key1", :value => "val1", :section => "additional_attributes" },
+                                       { :name => "key2", :value => "val2", :section => "additional_attributes" }]
+          )
+        ]
+      )
     end
 
     it "ignores custom attributes of a different node" do
@@ -1021,32 +985,14 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
       }
       parser.get_additional_attributes(inventory)
       parser.get_nodes(inventory)
-      expect(parser.instance_variable_get(:@data)[:container_nodes]).to eq([{
-        :name                  => 'test-node1',
-        :ems_ref               => 'f0c1fe7e-9c09-11e5-bb22-28d2447dcefe',
-        :ems_created_on        => '2016-01-01T11:10:21Z',
-        :container_conditions  => [],
-        :identity_infra        => 'aws:///zone/aws-id',
-        :labels                => [],
-        :tags                  => [],
-        :lives_on_id           => nil,
-        :lives_on_type         => nil,
-        :max_container_groups  => nil,
-        :computer_system       => {
-          :hardware         => {
-            :cpu_total_cores => nil,
-            :memory_mb       => nil
-          },
-          :operating_system => {
-            :distribution   => nil,
-            :kernel_version => nil
-          }
-        },
-        :namespace             => nil,
-        :resource_version      => '369104',
-        :type                  => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
-        :additional_attributes => [{ :name => "key1", :value => "val1", :section => "additional_attributes" }]
-      }])
+      expect(parser.instance_variable_get(:@data)[:container_nodes]).to match(
+        [
+          a_hash_including(
+            :name                  => 'test-node1',
+            :additional_attributes => [{ :name => "key1", :value => "val1", :section => "additional_attributes" }]
+          )
+        ]
+      )
     end
   end
 


### PR DESCRIPTION
We want to formulate graph refresh in a way that can process partial info independently.
Some pieces are still missing to actually achieve that, but it's clear we need to untangle parsing logic from the `@data_index` writes and reads that currently pervade it.

This PR refactors the *current* parser in that direction.
`parse_foo` methods will become pure functions processing their piece of the inventory;
only the `get_foos` methods will read and write `@data_index` to link the resulting hashes
(`get_foos_graph` methods introduced in #30 will do linking differently; I matching changes for them but let's review the non-graph part here.)

- Exception: image & registry parsing still *reads and writes* `@data_index` in-place.  I can live with that for now, will revisit it later.

cc @zakiva @enoodle @simon3z @agrare 
~~WIP because I still need to adapt refresh_parser_spec~~, but please review the refactoring.
(Recommend reviewing by commits)

@miq-bot add-label refactoring