### PR TITLE
Get rid of unnecessary magic ["table"] RecursiveOpenStruct access

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -63,7 +63,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
       :timestamp => event.object.lastTimestamp,
       :kind      => event.object.involvedObject.kind,
       :name      => event.object.involvedObject.name,
-      :namespace => event.object.involvedObject['table'][:namespace],
+      :namespace => event.object.involvedObject.namespace,
       :reason    => event.object.reason,
       :message   => event.object.message,
       :uid       => event.object.involvedObject.uid

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -568,7 +568,7 @@ module ManageIQ::Providers::Kubernetes
       end
 
       new_result[:project] = @data_index.fetch_path(path_for_entity("namespace"), :by_name,
-                                                    service.metadata["table"][:namespace])
+                                                    service.metadata.namespace)
       new_result
     end
 
@@ -594,7 +594,7 @@ module ManageIQ::Providers::Kubernetes
         new_result[:container_node] = @data_index.fetch_path(path_for_entity("node"), :by_name, pod.spec.nodeName)
       end
 
-      new_result[:project] = @data_index.fetch_path(path_for_entity("namespace"), :by_name, pod.metadata["table"][:namespace])
+      new_result[:project] = @data_index.fetch_path(path_for_entity("namespace"), :by_name, pod.metadata.namespace)
 
       # TODO, map volumes
       # TODO, podIP
@@ -645,9 +645,7 @@ module ManageIQ::Providers::Kubernetes
           next if address.targetRef.try(:kind) != 'Pod'
           cg = @data_index.fetch_path(
             path_for_entity("pod"), :by_namespace_and_name,
-            # namespace is overriden in more_core_extensions and hence needs
-            # a non method access
-            address.targetRef["table"][:namespace], address.targetRef.name)
+            address.targetRef.namespace, address.targetRef.name)
           new_result[:container_groups] << cg unless cg.nil?
         end
       end
@@ -720,7 +718,7 @@ module ManageIQ::Providers::Kubernetes
       new_result[:project] = @data_index.fetch_path(
         path_for_entity("namespace"),
         :by_name,
-        resource_quota.metadata["table"][:namespace])
+        resource_quota.metadata.namespace)
       new_result[:container_quota_items] = parse_quota_items resource_quota
       new_result
     end
@@ -755,7 +753,7 @@ module ManageIQ::Providers::Kubernetes
       new_result[:project] = @data_index.fetch_path(
         path_for_entity("namespace"),
         :by_name,
-        limit_range.metadata["table"][:namespace])
+        limit_range.metadata.namespace)
       new_result[:container_limit_items] = parse_range_items limit_range
       new_result
     end
@@ -819,7 +817,7 @@ module ManageIQ::Providers::Kubernetes
       )
 
       new_result[:project] = @data_index.fetch_path(path_for_entity("namespace"), :by_name,
-                                                    container_replicator.metadata["table"][:namespace])
+                                                    container_replicator.metadata.namespace)
       new_result
     end
 
@@ -1010,9 +1008,7 @@ module ManageIQ::Providers::Kubernetes
       {
         :ems_ref          => item.metadata.uid,
         :name             => item.metadata.name,
-        # namespace is overriden in more_core_extensions and hence needs
-        # a non method access
-        :namespace        => item.metadata["table"][:namespace],
+        :namespace        => item.metadata.namespace,
         :ems_created_on   => item.metadata.creationTimestamp,
         :resource_version => item.metadata.resourceVersion
       }

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -645,7 +645,8 @@ module ManageIQ::Providers::Kubernetes
           next if address.targetRef.try(:kind) != 'Pod'
           cg = @data_index.fetch_path(
             path_for_entity("pod"), :by_namespace_and_name,
-            address.targetRef.namespace, address.targetRef.name)
+            address.targetRef.namespace, address.targetRef.name
+          )
           new_result[:container_groups] << cg unless cg.nil?
         end
       end
@@ -718,7 +719,8 @@ module ManageIQ::Providers::Kubernetes
       new_result[:project] = @data_index.fetch_path(
         path_for_entity("namespace"),
         :by_name,
-        resource_quota.metadata.namespace)
+        resource_quota.metadata.namespace
+      )
       new_result[:container_quota_items] = parse_quota_items resource_quota
       new_result
     end
@@ -753,7 +755,8 @@ module ManageIQ::Providers::Kubernetes
       new_result[:project] = @data_index.fetch_path(
         path_for_entity("namespace"),
         :by_name,
-        limit_range.metadata.namespace)
+        limit_range.metadata.namespace
+      )
       new_result[:container_limit_items] = parse_range_items limit_range
       new_result
     end


### PR DESCRIPTION
> *Toi, toi, toi!* (from an old superstition): An exclamation after a statement or declaration in order to prevent a hex from being put on it, accompanied by knocking on a wooden object such as a **table** with one’s knuckles.
> — http://forward.com/culture/15158/spit-your-way-to-safety-toi-toi-toi/ [**emphasis** mine]
> 
> The origin of the custom may be in Germanic folklore, wherein supernatural beings are thought to live in trees, and can be invoked for protection.
> — https://en.wikipedia.org/wiki/Knocking_on_wood

In our case the `obj["table"][:namespace]` incantation summons the tree of hashes that dwells inside a RecursiveOpenStruct, to ward off a monkey patch.
The custom to say `obj["table"][:namespace]` probably arose because `obj[:namespace]` didn't work either until recursive-open-struct 1.0.3 — but it also relies on obscure bug fixed in same 1.0.3!  We happen to be indirectly pegged on 1.0.0 but would break soon.
(See https://github.com/aetherknight/recursive-open-struct/issues/51, `[]` used to invoke `send`, which sees any method including `#namespace` — but also including the normally protected `attr_accessor :table` inherited from ruby's `OpenStruct`...)

There are safer ways to avoid clash with a method (`.to_h[:namespace]`).
But luckily manageiq's `Object#namespace` monkey patch got removed in Aug 2015 (https://github.com/ManageIQ/more_core_extensions/pull/20), and *tfu tfu tfu* is not coming back, so the whole dance is unnecessary, we can just use `.namespace` access :-)

Tested against both r-o-s 1.0.0 and 1.0.4.

@miq-bot add-label bug, technical dept

@simon3z @moolitayer I believe we should backport this.  Alternatively could peg older manageiq releases to r-o-s < 1.0.3 but that might prevent kubeclient / image-inspector-client upgrades.