### PR TITLE
[WIP] Disable use of docker socket / privileged mode when running image-inspector

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -386,16 +386,11 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
               "--chroot",
               "--image=#{options[:image_full_name]}",
               "--scan-type=openscap",
-              "--serve=0.0.0.0:#{options[:pod_port]}"
+              "--serve=0.0.0.0:#{options[:pod_port]}",
+              "--use-docker-socket=false",
+              "--registry-cert-path=/var/run/secrets/kubernetes.io/serviceaccount/"
             ],
             :ports           => [{:containerPort => options[:pod_port]}],
-            :securityContext => {:privileged =>  true},
-            :volumeMounts    => [
-              {
-                :mountPath => DOCKER_SOCKET,
-                :name      => "docker-socket"
-              }
-            ],
             :env             => inspector_proxy_env_variables,
             :readinessProbe  => {
               "initialDelaySeconds" => 15,
@@ -404,15 +399,11 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
                 "path" => "/healthz",
                 "port" => options[:pod_port]
               }
-            }
+            },
+            :volumeMounts => []
           }
         ],
-        :volumes       => [
-          {
-            :name     => "docker-socket",
-            :hostPath => {:path => DOCKER_SOCKET}
-          }
-        ]
+        :volumes => []
       }
     }
 


### PR DESCRIPTION
As of https://github.com/openshift/image-inspector/pull/58 image-inspector no longer requires running in privileged mode and connecting to the docker socket in order to inspect images.

This PR will modify the pod spec to start the image-inspector with this updated configuration