### PR TITLE
Pass userid before going to automation

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -158,14 +158,15 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   end
 
   def scan_job_create(entity)
-    check_policy_prevent(:request_containerimage_scan, entity, :raw_scan_job_create)
+    check_policy_prevent(:request_containerimage_scan, entity, User.current_user.userid, :raw_scan_job_create)
   end
 
-  def raw_scan_job_create(target_class, target_id = nil)
+  def raw_scan_job_create(target_class, target_id = nil, userid = nil)
     target_class, target_id = target_class.class.name, target_class.id if target_class.kind_of?(ContainerImage)
+    userid ||= User.current_user.userid
     Job.create_job(
       "ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job",
-      :userid          => User.current_user.userid,
+      :userid          => userid,
       :name            => "Container image analysis",
       :target_class    => target_class,
       :target_id       => target_id,
@@ -179,12 +180,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   # policy_event: the event sent to automate for policy resolution
   # cb_method:    the MiqQueue callback method along with the parameters that is called
   #               when automate process is done and the event is not prevented to proceed by policy
-  def check_policy_prevent(policy_event, event_target, cb_method)
+  def check_policy_prevent(policy_event, event_target, userid, cb_method)
     cb = {
       :class_name  => self.class.to_s,
       :instance_id => id,
       :method_name => :check_policy_prevent_callback,
-      :args        => [cb_method, event_target.class.name, event_target.id],
+      :args        => [cb_method, event_target.class.name, event_target.id, userid],
       :server_guid => MiqServer.my_guid
     }
     enforce_policy(event_target, policy_event, {}, { :miq_callback => cb }) unless policy_event.nil?

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -79,8 +79,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
     context "#initialize" do
       it "Creates a new scan job" do
         image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
-        User.current_user = FactoryGirl.create(:user, :userid => "bob")
-        job = @ems.raw_scan_job_create(image.class, image.id)
+        job = @ems.raw_scan_job_create(image.class, image.id, "bob")
         expect(job).to have_attributes(
           :dispatch_status => "pending",
           :state           => "waiting_to_start",
@@ -96,6 +95,21 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
         image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
         User.current_user = FactoryGirl.create(:user, :userid => "bob")
         job = @ems.raw_scan_job_create(image)
+        expect(job).to have_attributes(
+          :dispatch_status => "pending",
+          :state           => "waiting_to_start",
+          :status          => "ok",
+          :message         => "process initiated",
+          :target_class    => "ContainerImage",
+          :userid          => "bob"
+        )
+      end
+
+      it "Is backward compatible with #54" do
+        # https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/54/files
+        image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
+        User.current_user = FactoryGirl.create(:user, :userid => "bob")
+        job = @ems.raw_scan_job_create(image.class, image.id)
         expect(job).to have_attributes(
           :dispatch_status => "pending",
           :state           => "waiting_to_start",


### PR DESCRIPTION
Calculating user in `raw_scan_job_create` is too late since it is called from automate and always evaluates to admin at that point.

https://bugzilla.redhat.com/show_bug.cgi?id=1460754