### PR TITLE
Update disconnection test to understand soft delete

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -516,7 +516,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
   def assert_disconnected(object)
     expect(object).not_to be_nil
     expect(object.deleted_on).not_to be_nil
-    expect(object.ext_management_system).to be_nil
-    expect(object.old_ems_id).to eq(@ems.id)
+    expect(object.archived?).to be true
   end
 end


### PR DESCRIPTION
Disconnect tests added in #44 were expecting ems_id to become nil,
which doesn't happen after soft delete https://github.com/ManageIQ/manageiq/pull/15251.
Fixed by asking `.archived?` instead.