### PR TITLE
Update Hawkular version

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "hawkular-client", "~> 3.0.2"
+  s.add_runtime_dependency "hawkular-client", "~> 4.1"
   s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"
   s.add_runtime_dependency "kubeclient",      "~>2.4.0"
 


### PR DESCRIPTION
Recently, we released a new version of Hawkular, doing some breaking changes in the process. The changes are mainly related to error handling, so there's nothing to change on the provider.

However, if you do want to take advantage of the new features, now you can catch any and all Hawkular errors by rescuing `Hawkular::ConnectionException` for connection-related issues, `Hawkular::ArgumentError` for improper usage of the library, and `Hawkular::Exception` as a catch-all.

Depends on: https://github.com/ManageIQ/manageiq-providers-hawkular/pull/26