### PR TITLE
Fix support_metrics function to include prometheus

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -5,6 +5,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   extend ActiveSupport::Concern
 
   DEFAULT_PORT = 6443
+  METRICS_ROLES = %w(prometheus hawkular).freeze
+
   included do
     default_value_for :port do |provider|
       # port is not a column on this table, it's delegated to endpoint.
@@ -15,7 +17,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   end
 
   def supports_metrics?
-    connection_configurations.hawkular != nil
+    endpoints.where(:role => METRICS_ROLES).exists?
   end
 
   module ClassMethods

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -9,6 +9,59 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
     expect(described_class.raw_api_endpoint("::1", 123).to_s).to eq "https://[::1]:123"
   end
 
+  context "#supports_metrics?" do
+    before(:each) do
+      EvmSpecHelper.local_miq_server(:zone => Zone.seed)
+    end
+
+    it "regular provider has no metrics support" do
+      ems = FactoryGirl.create(
+        :ems_kubernetes,
+        :endpoints => [
+          Endpoint.new(:role => 'default', :hostname => 'hostname')
+        ]
+      )
+
+      expect(ems.supports_metrics?).to be_falsey
+    end
+
+    it "provider with hawkular endpoint has metrics support" do
+      ems = FactoryGirl.create(
+        :ems_kubernetes,
+        :endpoints => [
+          Endpoint.new(:role => 'default', :hostname => 'hostname'),
+          Endpoint.new(:role => 'hawkular')
+        ]
+      )
+
+      expect(ems.supports_metrics?).to be_truthy
+    end
+
+    it "provider with prometheus endpoint has metrics support" do
+      ems = FactoryGirl.create(
+        :ems_kubernetes,
+        :endpoints => [
+          Endpoint.new(:role => 'default', :hostname => 'hostname'),
+          Endpoint.new(:role => 'prometheus')
+        ]
+      )
+
+      expect(ems.supports_metrics?).to be_truthy
+    end
+
+    it "provider with some role endpoint has no metrics support" do
+      ems = FactoryGirl.create(
+        :ems_kubernetes,
+        :endpoints => [
+          Endpoint.new(:role => 'default', :hostname => 'hostname'),
+          Endpoint.new(:role => 'some_role')
+        ]
+      )
+
+      expect(ems.supports_metrics?).to be_falsey
+    end
+  end
+
   context "#verify_ssl_mode" do
     let(:ems) { FactoryGirl.build(:ems_kubernetes) }
 


### PR DESCRIPTION
**Description**

The kubernetes provider supports metrics from prometheus, currently the `supports_metrics?` fails to recognize this endpoint.

This PR fixes that.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1470537
