### PR TITLE
[WIP] match registry to service with >1 port configs

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -1173,4 +1173,59 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         })
     end
   end
+
+  context "services" do
+    let(:service) do
+      array_recursive_ostruct(
+        :metadata => {
+          :name              => "docker-registry",
+          :namespace         => "default",
+          :selfLink          => "/api/v1/namespaces/default/services/docker-registry",
+          :uid               => "13d3bcf7-e6f9-11e6-a348-001a4a162683",
+          :resourceVersion   => "651",
+          :creationTimestamp => "2017-01-30T14:33:33Z",
+          :labels            => {:"docker-registry" => "default"},
+        },
+        :spec     => {
+          :ports           => [
+            {:name => "5000-tcp", :protocol => "TCP", :port => 5000, :targetPort => 5000},
+          ],
+          :selector        => {:"docker-registry" => "default"},
+          :portalIP        => "172.30.185.88",
+          :clusterIP       => "172.30.185.88",
+          :type            => "ClusterIP",
+          :sessionAffinity => "ClientIP",
+        },
+        :status   => {
+          :loadBalancer => {}
+        },
+      )
+    end
+
+    describe "parse_service" do
+      it "handles simple data" do
+        expect(parser.parse_service(service)).to eq(
+          :ems_ref                        => "13d3bcf7-e6f9-11e6-a348-001a4a162683",
+          :name                           => "docker-registry",
+          :namespace                      => "default",
+          :ems_created_on                 => "2017-01-30T14:33:33Z",
+          :resource_version               => "651",
+          :portal_ip                      => "172.30.185.88",
+          :session_affinity               => "ClientIP",
+          :service_type                   => "ClusterIP",
+          :labels                         => [
+            {:section => "labels", :source => "kubernetes", :name => "docker-registry", :value => "default"},
+          ],
+          :tags                           => [],
+          :selector_parts                 => [
+            {:section => "selectors", :source => "kubernetes", :name => "docker-registry", :value => "default"},
+          ],
+          :container_service_port_configs => [
+            {:ems_ref => "13d3bcf7-e6f9-11e6-a348-001a4a162683_5000_5000",
+             :name => "5000-tcp", :protocol => "TCP", :port => 5000, :target_port => 5000, :node_port => nil},
+          ]
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes a (theoretical) bug in matching registries host:ports we see in images to registry service(s) running in the cluster.  If the service has many ports, match would only succeed for last port (previous iterations of the loop were overwritten).

@miq-bot add-label bug
@simon3z I think this is very theoretical, no point backporting?

This PR only touches old hashes→save_inventory refresh, for now doing graph refresh with last-port logic and a TODO as I don't yet know how to implemet correct logic there.
Also adds tests to this part of the parser.  (With 1 port, it's also already covered in *openshift* repo VCR refersher_spec, which still passes.)
