### PR TITLE
recurse_over_array in more places representing KubeClient outputs

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -79,7 +79,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           :container_namespace  => 'openshift-infra',
           :event_type           => 'CONTAINER_KILLING'
         }
-        event = RecursiveOpenStruct.new(:object => kubernetes_event)
+        event = array_recursive_ostruct(:object => kubernetes_event)
         expect(test_class.new.extract_event_data(event)).to eq(expected_data)
       end
     end
@@ -164,7 +164,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           :container_namespace       => 'proj',
           :event_type                => 'REPLICATOR_SUCCESSFULCREATE'
         }
-        event = RecursiveOpenStruct.new(:object => kubernetes_event)
+        event = array_recursive_ostruct(:object => kubernetes_event)
         expect(test_class.new.extract_event_data(event)).to eq(expected_data)
       end
     end
@@ -218,7 +218,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
       end
 
       it 'given good uid extracts NODE_REBOOTED event data' do
-        event = RecursiveOpenStruct.new(:object => kubernetes_event)
+        event = array_recursive_ostruct(:object => kubernetes_event)
         expect(test_class.new.extract_event_data(event)).to eq(expected_data)
       end
 
@@ -227,7 +227,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
       context 'given useless/missing uid' do
         # We've seen events with both missing uid and uid == name.
         let(:bad_uid_event) do
-          RecursiveOpenStruct.new(:object => kubernetes_event.merge(
+          array_recursive_ostruct(:object => kubernetes_event.merge(
             'involvedObject' => {
               'kind' => 'Node',
               'name' => 'vm-test-03.example.com',
@@ -237,7 +237,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
         end
 
         let(:missing_uid_event) do
-          RecursiveOpenStruct.new(:object => kubernetes_event.merge(
+          array_recursive_ostruct(:object => kubernetes_event.merge(
             'involvedObject' => {
               'kind' => 'Node',
               'name' => 'vm-test-03.example.com'

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -1,6 +1,8 @@
 require 'MiqContainerGroup/MiqContainerGroup'
 
 class MockKubeClient
+  include ArrayRecursiveOpenStruct
+
   def create_pod(*_args)
     nil
   end
@@ -14,7 +16,7 @@ class MockKubeClient
   end
 
   def get_pod(*_args)
-    RecursiveOpenStruct.new(
+    array_recursive_ostruct(
       :metadata => {
         :annotations => {
           'manageiq.org/jobid' => '5'
@@ -29,12 +31,12 @@ class MockKubeClient
   end
 
   def get_service_account(*_args)
-    RecursiveOpenStruct.new(
+    array_recursive_ostruct(
       :metadata         => {
         :name => 'inspector-admin'
       },
       :imagePullSecrets => [
-        OpenStruct.new(:name => 'inspector-admin-dockercfg-blabla')
+        { :name => 'inspector-admin-dockercfg-blabla' }
       ]
     )
   end


### PR DESCRIPTION
Followup to #58.

Not touching MockImageInspectorClient as real ImageInspectorClient doesn't use recurse_over_array (its data don't contain arrays anyway).

@miq-bot add-labels refactoring, test