### PR TITLE
Use k8s provider in k8s tests

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_spec.rb
@@ -5,8 +5,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Hawk
     token = 'the_token'
 
     @ems = FactoryGirl.create(
-      :ems_openshift,
-      :name                      => 'OpenShiftProvider',
+      :ems_kubernetes,
+      :name                      => 'KubernetesProvider',
       :connection_configurations => [{:endpoint       => {:role     => :default,
                                                           :hostname => hostname,
                                                           :port     => "8443"},


### PR DESCRIPTION
Should fix test failures of https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/38