### PR TITLE
Volume-related graph refresh fixes & VCR specs

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
@@ -313,11 +313,13 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
     @collections[:persistent_volume_claims] =
       ::ManagerRefresh::InventoryCollection.new(
         shared_options.merge(
-          :model_class    => PersistentVolumeClaim,
-          :parent         => manager,
-          :builder_params => {:ems_id => manager.id},
-          :association    => :persistent_volume_claims,
-          :use_ar_object  => true # serialized :capacity attr
+          :model_class          => PersistentVolumeClaim,
+          :parent               => manager,
+          :builder_params       => {:ems_id => manager.id},
+          :association          => :persistent_volume_claims,
+          :use_ar_object        => true, # serialized :capacity attr
+          :secondary_refs       => {:by_namespace_and_name => [:namespace, :name]},
+          :attributes_blacklist => [:namespace],
         )
       )
   end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -419,9 +419,13 @@ module ManageIQ::Providers::Kubernetes
     # polymorphic, relation disambiguates parent
     def get_container_conditions_graph(parent, hashes)
       model_name = parent.inventory_collection.model_class.base_class.name
+      key = [:container_conditions_for, model_name]
+      collection = @inv_collections[key]
+      raise("can't save: missing @inv_collections[#{key}]") if collection.nil?
+
       hashes.to_a.each do |h|
         h = h.merge(:container_entity => parent)
-        @inv_collections[[:container_conditions_for, model_name]].build(h)
+        collection.build(h)
       end
     end
 

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -129,6 +129,13 @@ module ManageIQ::Providers::Kubernetes
           path_for_entity("replication_controller"), :by_namespace_and_name,
           replicator_ref[:namespace], replicator_ref[:name]
         )
+        cg[:container_volumes].each do |cv|
+          pvc_ref = cv.delete(:persistent_volume_claim_ref)
+          cv[:persistent_volume_claim] = pvc_ref && @data_index.fetch_path(
+            path_for_entity("persistent_volume_claim"),
+            :by_namespace_and_name, pvc_ref[:namespace], pvc_ref[:name]
+          )
+        end
         # Note: save_container_groups_inventory also links build_pod by :build_pod_name.
 
         @data_index.store_path(key, :by_namespace_and_name,
@@ -425,6 +432,14 @@ module ManageIQ::Providers::Kubernetes
 
       hashes.to_a.each do |h|
         h = h.merge(:container_entity => parent)
+        collection.build(h)
+      end
+    end
+
+    def get_container_volumes_graph(parent, hashes)
+      collection = @inv_collections[:container_volumes]
+      hashes.to_a.each do |h|
+        h = h.merge(:parent => parent)
         collection.build(h)
       end
     end
@@ -1233,14 +1248,17 @@ module ManageIQ::Providers::Kubernetes
 
     def parse_volumes(pod)
       pod.spec.volumes.to_a.collect do |volume|
-        {
-          :type                    => 'ContainerVolume',
-          :name                    => volume.name,
-          :persistent_volume_claim => @data_index.fetch_path(path_for_entity("persistent_volume_claim"),
-                                                             :by_namespace_and_name,
-                                                             pod.metadata.namespace,
-                                                             volume.persistentVolumeClaim.try(:claimName))
+        new_result = {
+          :type => 'ContainerVolume',
+          :name => volume.name,
         }.merge!(parse_volume_source(volume))
+        if volume.persistentVolumeClaim.try(:claimName)
+          new_result[:persistent_volume_claim_ref] = {
+            :namespace => pod.metadata.namespace,
+            :name      => volume.persistentVolumeClaim.claimName,
+          }
+        end
+        new_result
       end
     end
 


### PR DESCRIPTION
Added refresher specs for CVs, PVs, PVCs.
Testing those in the new easier-to-reproduce VCRs.  I was lazy and avoided re-recording but relying on some hawkular/cassandra stuff that's not in the template — but should be pretty stable.

@miq-bot add-label bug, test

Graph refresh RFE: https://bugzilla.redhat.com/show_bug.cgi?id=1470021
