### PR TITLE
Allow nil parent for tests

### DIFF
--- a/app/models/manageiq/providers/kubernetes/monitoring_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/monitoring_manager_mixin.rb
@@ -5,7 +5,8 @@ module ManageIQ::Providers::Kubernetes::MonitoringManagerMixin
   included do
     delegate :authentications,
              :endpoints,
-             :to => :parent_manager
+             :to        => :parent_manager,
+             :allow_nil => true
 
     default_value_for :port do |manager|
       manager.port || DEFAULT_PORT
@@ -19,7 +20,7 @@ module ManageIQ::Providers::Kubernetes::MonitoringManagerMixin
   end
 
   def default_endpoint
-    endpoints.detect { |x| x.role == ENDPOINT_ROLE.to_s }
+    endpoints && endpoints.detect { |x| x.role == ENDPOINT_ROLE.to_s }
   end
 
   def supports_port?


### PR DESCRIPTION
Like other managers with parents, we must `allow_nil` to pass 
manageiq-ui-classic's `tree_node_spec.rb` creation with out a parent obeject (which should never happen in real life). Reproduce using `ManageIQ::Providers::Openshift::MonitoringManager.new` (as @himdel pointed out)