### PR TITLE
Fix "unused HTTP interactions", make test more robust

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context_spec.rb
@@ -29,9 +29,11 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Hawk
       VCR.use_cassette("#{described_class.name.underscore}_refresh",
                        :match_requests_on => [:path,]) do # , :record => :new_episodes) do
         EmsRefresh.refresh(@ems)
-        @node = @ems.container_nodes.first
-        pod = @ems.container_groups.first
-        container = @ems.containers.first
+        @ems.reload
+
+        @node = @ems.container_nodes.find_by(:name => "capture.context.com")
+        pod = @ems.container_groups.find_by(:name => "docker-registry-1-w23wd")
+        container = pod.containers.find_by(:name => "registry")
 
         @targets = [['node', @node], ['pod', pod], ['container', container]]
       end


### PR DESCRIPTION
The `.find_by` instead of `.first` will make the tested targets stable and matching the VCR even if refresh record order changes.
It also happens to fix VCR errors following #42, but not because of order.
`.first` returned same record as `.find_by` but behavior differed!

The reason is that without `.reload` after refresh, ActiveRecord caches were stale, with unpredictable results...
(Exact queries during refresh changed in #42, with the result that `pod = @ems.container_groups.first` did not go to DB, and `pod.containers` weirdly returned same container twice.)