### PR TITLE
Add ContainerImage raise event post processing job

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
@@ -37,7 +37,7 @@ module ManageIQ
             container_images_ids = batch.collect { |x| x[:id] }
             MiqQueue.submit_job(
               :class_name  => "ContainerImage",
-              :method_name => 'raise_creation_event',
+              :method_name => 'raise_creation_events',
               :args        => [container_images_ids],
               :priority    => MiqQueue::HIGH_PRIORITY
             )

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
@@ -39,7 +39,7 @@ module ManageIQ
               :class_name  => "ContainerImage",
               :method_name => 'raise_creation_event',
               :args        => [container_images_ids],
-              :priority    => MiqQueue::MIN_PRIORITY
+              :priority    => MiqQueue::HIGH_PRIORITY
             )
           end
         end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
@@ -21,6 +21,28 @@ module ManageIQ
             end
           end
         end
+
+        def manager_refresh_post_processing(_ems, _target, inventory_collections)
+          indexed = inventory_collections.index_by(&:name)
+          container_images_post_processing(indexed[:container_images])
+        end
+
+        def container_images_post_processing(container_images)
+          # We want this post processing job only for batches, for the rest it's after_create hook on the Model
+          return unless container_images.saver_strategy == :batch
+
+          # TODO extract the batch size to Settings
+          batch_size = 100
+          container_images.created_records.each_slice(batch_size) do |batch|
+            container_images_ids = batch.collect { |x| x[:id] }
+            MiqQueue.submit_job(
+              :class_name  => "ContainerImage",
+              :method_name => 'raise_creation_event',
+              :args        => [container_images_ids],
+              :priority    => MiqQueue::MIN_PRIORITY
+            )
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/15678
- [x] https://github.com/ManageIQ/manageiq/pull/15679

Add ContainerImage raise event post processing job, queuing
the raise event as a background job, since it does not
belong under the refresh.