### PR TITLE
Fix fallouts from ContainerTemplate STI

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
   require_nested :Container
   require_nested :ContainerGroup
   require_nested :ContainerNode
+  require_nested :ContainerTemplate
   require_nested :EventCatcher
   require_nested :EventCatcherMixin
   require_nested :EventParser

--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
@@ -325,10 +325,10 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
   # ContainerCondition is polymorphic child of ContainerNode & ContainerGroup.
   def initialize_container_conditions_collection(relation)
     query = ContainerCondition.where(
-      :container_entity_type => relation.model.name,
+      :container_entity_type => relation.model.base_class.name,
       :container_entity_id   => relation, # nested SELECT. TODO: compare to a JOIN.
     )
-    @collections[[:container_conditions_for, relation.model.name]] =
+    @collections[[:container_conditions_for, relation.model.base_class.name]] =
       ::ManagerRefresh::InventoryCollection.new(
         shared_options.merge(
           :model_class => ContainerCondition,
@@ -342,11 +342,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
   def initialize_custom_attributes_collections(relation, sections)
     sections.each do |section|
       query = CustomAttribute.where(
-        :resource_type => relation.model.name,
+        :resource_type => relation.model.base_class.name,
         :resource_id   => relation,
         :section       => section.to_s
       )
-      @collections[[:custom_attributes_for, relation.model.name, section.to_s]] =
+      @collections[[:custom_attributes_for, relation.model.base_class.name, section.to_s]] =
         ::ManagerRefresh::InventoryCollection.new(
           shared_options.merge(
             :model_class => CustomAttribute,

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -418,7 +418,7 @@ module ManageIQ::Providers::Kubernetes
 
     # polymorphic, relation disambiguates parent
     def get_container_conditions_graph(parent, hashes)
-      model_name = parent.inventory_collection.model_class.name
+      model_name = parent.inventory_collection.model_class.base_class.name
       hashes.to_a.each do |h|
         h = h.merge(:container_entity => parent)
         @inv_collections[[:container_conditions_for, model_name]].build(h)
@@ -554,7 +554,7 @@ module ManageIQ::Providers::Kubernetes
     end
 
     def get_custom_attributes_graph(parent, hashes_by_section)
-      model_name = parent.inventory_collection.model_class.name
+      model_name = parent.inventory_collection.model_class.base_class.name
       hashes_by_section.each do |section, hashes|
         key = [:custom_attributes_for, model_name, section.to_s]
         collection = @inv_collections[key]


### PR DESCRIPTION
I assumed in this code the model used when defining these collections is same model as the `parent` for which we are looking them up, which is wrong given STI.
This fixes errors in manageiq-providers-openshift repo:
```
    can't save: missing @inv_collections[[:custom_attributes_for, "ContainerTemplate", "labels"]]
    can't save: missing @inv_collections[[:custom_attributes_for, "ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplate", "labels"]]
```
following https://github.com/ManageIQ/manageiq-providers-openshift/pull/28 and related PRs.

I'm still seeing other errors in openshift specs locally, but this gets us closer to green...

@lfu @moolitayer @Ladas please review.