### PR TITLE
Adding test for number_of_containers method for ContainerImage

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/container_image_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/container_image_spec.rb
@@ -10,6 +10,10 @@ describe ContainerImage do
       :containers => [FactoryGirl.create(:container, :name => "container_a", :container_group => group),
                       FactoryGirl.create(:container, :name => "container_b", :container_group => group)]
     ).container_nodes.count).to eq(1)
+    expect(FactoryGirl.create(
+      :container_image,
+      :containers => [FactoryGirl.create(:container, :name => "container_a", :container_group => group),
+                      FactoryGirl.create(:container, :name => "container_b", :container_group => group)]
+    ).number_of_containers).to eq(2)
     end
 end
-


### PR DESCRIPTION
Adding test for `number_of_containers` method for `ContainerImage`.

cc: @enoodle 
@simon3z 

related to: https://github.com/ManageIQ/manageiq/pull/15741, https://github.com/ManageIQ/manageiq-ui-classic/pull/1840