### PR TITLE
Use EntitiesMapping in Container Template

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/container_template_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_template_mixin.rb
@@ -1,18 +1,6 @@
 module ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplateMixin
   extend ActiveSupport::Concern
-
-  MIQ_ENTITY_MAPPING = {
-    "Route"                 => ContainerRoute,
-    "Build"                 => ContainerBuildPod,
-    "BuildConfig"           => ContainerBuild,
-    "Template"              => ContainerTemplate,
-    "ResourceQuota"         => ContainerQuota,
-    "LimitRange"            => ContainerLimit,
-    "ReplicationController" => ContainerReplicator,
-    "PersistentVolumeClaim" => PersistentVolumeClaim,
-    "Pod"                   => ContainerGroup,
-    "Service"               => ContainerService,
-  }.freeze
+  include ManageIQ::Providers::Kubernetes::ContainerManager::EntitiesMapping
 
   def instantiate(params, project = nil)
     project ||= container_project.name
@@ -24,7 +12,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplateMixin
                                           :objects    => objects,
                                           :parameters => params)
     create_objects(processed_template['objects'], project)
-    @created_objects.each { |obj| obj[:miq_class] = MIQ_ENTITY_MAPPING[obj[:kind]] }
+    @created_objects.each { |obj| obj[:miq_class] = model_by_entity(obj[:kind].underscore) }
   end
 
   def process_template(client, template)

--- a/app/models/manageiq/providers/kubernetes/container_manager/entities_mapping.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/entities_mapping.rb
@@ -30,4 +30,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EntitiesMapping
   def entity_by_resource(entity)
     MAPPING.key(entity)
   end
+
+  def model_by_entity(entity)
+    resource_by_entity(entity).try(:constantize)
+  end
 end


### PR DESCRIPTION
We can now use the [entities mapping](https://github.com/ManageIQ/manageiq-providers-kubernetes/blob/master/app/models/manageiq/providers/kubernetes/container_manager/entities_mapping.rb)  to map the objects kind to a miq class after instantiation. 
Moved from https://github.com/ManageIQ/manageiq/pull/13619
@moolitayer @simon3z Please review 