### PR TITLE
Manually edit cassette that I believe was manually misedited

### DIFF
--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/refresher.yml
@@ -1,3 +1,5 @@
+# Note: this cassette has been manually edited, probably more than once,
+# and doesn't necessarily represent ground truth.
 ---
 http_interactions:
 - request:
@@ -602,7 +604,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"kind":"ComponentStatusList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/componentstatuses"},"items":[{"metadata":{"name":"controller-manager","selfLink":"/api/v1/namespaces/componentstatuses/controller-manager","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"Unknown","error":"Get
         http://127.0.0.1:10252/healthz: dial tcp 127.0.0.1:10252: connection refused"}]},{"metadata":{"name":"scheduler","selfLink":"/api/v1/namespaces/componentstatuses/scheduler","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"Unknown","error":"Get
-        http://127.0.0.1:10251/healthz: dial tcp 127.0.0.1:10251: connection refused"}]},{"metadata":{"name":"etcd-0","selfLink":"/api/v1/namespaces/componentstatuses/etcd-0","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"True","message":{"health":"true"},"error":"nil"}]}]}'
+        http://127.0.0.1:10251/healthz: dial tcp 127.0.0.1:10251: connection refused"}]},{"metadata":{"name":"etcd-0","selfLink":"/api/v1/namespaces/componentstatuses/etcd-0","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"True","message":"{\"health\":\"true\"}","error":"nil"}]}]}'
     http_version:
   recorded_at: Tue, 13 Oct 2015 13:03:20 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
This cassette shows 1 of 3 componentstatus.message field containing a sub-*hash* `{"health":"true"}` rather than a string.  I can't reproduce that on any live cluster nor cassette, it's always a string.
Evidence it was actually the *string* `'{"health":"true"}'`:

- refresh_parser_spec from [same commit](https://github.com/ManageIQ/manageiq/pull/4891) has `'{...}'` string!
- https://github.com/kubernetes/kubernetes/issues/16721#issue-114767348 by dkorn from same time shows `'{...}'` string
- https://github.com/openshift/origin/issues/5570#issuecomment-153020811 by another person from same time shows `'{...}'` string
- api/types.go had `message String` ever since it was added
  https://github.com/kubernetes/kubernetes/commit/951a125751d5985750c82e919ab151a117bc5a94
- I see other signs this cassette was manually edited, multiple times.

If anyone has doubts, I could do a one-liner parser change to tolerate a hash better.

This does not really affect anything, componentstatus is broken in openshift and [hidden in UI](https://github.com/ManageIQ/manageiq/issues/8572).

@miq-bot add-label test

@yaacov @zakiva Please review.