### PR TITLE
rename provider_settings to options_description

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/options.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/options.rb
@@ -57,7 +57,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::Options
       }
     end
 
-    def provider_settings
+    def options_description
       {
         :proxy_settings    => {
           :label     => N_('Proxy Settings'),


### PR DESCRIPTION
Based on https://github.com/ManageIQ/manageiq/pull/15799#pullrequestreview-56271746 I suggest renaming this function for clarity.