### PR TITLE
A spec/support/ directory to be reused by openshift repo

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,17 +8,6 @@ VCR.configure do |config|
   config.cassette_library_dir = File.join(ManageIQ::Providers::Kubernetes::Engine.root, 'spec/vcr_cassettes')
 end
 
-# Helps constructing inputs similar to kubeclient results
-module ArrayRecursiveOpenStruct
-  def array_recursive_ostruct(hash)
-    RecursiveOpenStruct.new(hash, :recurse_over_arrays => true)
-  end
-end
-
-RSpec.configure do |c|
-  c.include ArrayRecursiveOpenStruct
-  c.extend ArrayRecursiveOpenStruct
-end
-
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
+# This repo's spec/support/ is also used by manageiq-providers-openshift.
 Dir[ManageIQ::Providers::Kubernetes::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }

--- a/spec/support/array_recursive_ostruct.rb
+++ b/spec/support/array_recursive_ostruct.rb
@@ -1,0 +1,11 @@
+# Helps constructing inputs similar to kubeclient results
+module ArrayRecursiveOpenStruct
+  def array_recursive_ostruct(hash)
+    RecursiveOpenStruct.new(hash, :recurse_over_arrays => true)
+  end
+end
+
+RSpec.configure do |c|
+  c.include ArrayRecursiveOpenStruct
+  c.extend ArrayRecursiveOpenStruct
+end


### PR DESCRIPTION
Specifically will allow
https://github.com/ManageIQ/manageiq-providers-openshift/pull/35 to
reuse `array_recursive_ostruct` helper from here, instead of duplicating it.

@miq-bot add-label test