### PR TITLE
Skip invalid container_images

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -766,8 +766,14 @@ module ManageIQ::Providers::Kubernetes
 
       unless pod.status.nil? || pod.status.containerStatuses.nil?
         pod.status.containerStatuses.each do |cn|
+          container_status = parse_container_status(cn, pod.metadata.uid)
+          if container_status.nil?
+            _log.error("Invalid container status: pod - [#{pod.metadata.uid}] container - [#{cn}] [#{containers_index[cn.name]}]")
+            next
+          end
+
           containers_index[cn.name] ||= {}
-          containers_index[cn.name].merge!(parse_container_status(cn, pod.metadata.uid))
+          containers_index[cn.name].merge!(container_status)
         end
       end
 
@@ -1077,11 +1083,14 @@ module ManageIQ::Providers::Kubernetes
     end
 
     def parse_container_status(container, pod_id)
+      container_image = parse_container_image(container.image, container.imageID)
+      return if container_image.nil?
+
       h = {
         :type            => 'ManageIQ::Providers::Kubernetes::ContainerManager::Container',
         :restart_count   => container.restartCount,
         :backing_ref     => container.containerID,
-        :container_image => parse_container_image(container.image, container.imageID)
+        :container_image => container_image
       }
       state_attributes = parse_container_state container.lastState
       state_attributes.each { |key, val| h[key.to_s.prepend('last_').to_sym] = val } if state_attributes
@@ -1102,6 +1111,8 @@ module ManageIQ::Providers::Kubernetes
 
     def parse_container_image(image, imageID)
       container_image, container_image_registry = parse_image_name(image, imageID)
+      return if container_image.nil?
+
       host_port = nil
 
       unless container_image_registry.nil?
@@ -1199,8 +1210,18 @@ module ManageIQ::Providers::Kubernetes
             (?<digest>(sha256:)?.+)?
         \z
       }x
+
       image_parts = docker_pullable_re.match(image)
+      if image_parts.nil?
+        _log.error("Invalid image #{image}")
+        return
+      end
+
       image_ref_parts = docker_pullable_re.match(image_ref) || docker_daemon_re.match(image_ref)
+      if image_ref_parts.nil?
+        _log.error("Invalid image_ref #{image_ref}")
+        return
+      end
 
       if image_ref.start_with?(ContainerImage::DOCKER_PULLABLE_PREFIX)
         hostname = image_ref_parts[:host] || image_ref_parts[:host2]

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -188,6 +188,16 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                        :image_ref  => example_ref,
                        :image      => {:name => "example", :tag => nil, :digest => "sha256:1234567abcdefg",
                                        :image_ref => "docker://example@sha256:1234567abcdefg"},
+                       :registry   => nil},
+
+                      {:image_name => "localhost:1234/name",
+                       :image_ref  => nil,
+                       :image      => nil,
+                       :registry   => nil},
+
+                      {:image_name => nil,
+                       :image_ref  => example_ref,
+                       :image      => nil,
                        :registry   => nil}]
 
     example_images.each do |ex|

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -217,6 +217,22 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
     end
   end
 
+  describe "parse_container_status" do
+    let(:image)   { "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ" }
+    let(:imageID) { "docker://#{image}" }
+    let(:pod_id)  { "af3d1a10-23d3-11e5-44c0-0af3d1a10370e" }
+
+    it "handles invalid image" do
+      container = array_recursive_ostruct(:image => nil, :imageID => imageID)
+      expect(parser.send(:parse_container_status, container, pod_id)).to be_nil
+    end
+
+    it "handles invalid imageID" do
+      container = array_recursive_ostruct(:image => image, :imageID => nil)
+      expect(parser.send(:parse_container_status, container, pod_id)).to be_nil
+    end
+  end
+
   describe "parse_volumes" do
     example_volumes = [
       {


### PR DESCRIPTION
```
[----] E, [2017-08-08T05:55:00.221227 #15805:1041130] ERROR -- : [NoMethodError]: undefined method `[]' for nil:NilClass  Method:[rescue in block in refresh]
[----] E, [2017-08-08T05:55:00.221475 #15805:1041130] ERROR -- : /var/www/miq/vmdb/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb:767:in `parse_image_name'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1484337