### PR TITLE
Move logging in trap context to a normal signal handler

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -42,6 +42,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
       # asynchronously when available.
       @queue.enq event
     end
+  rescue SignalException => e
+    if e.message == "SIGTERM"
+      $kube_log.info("#{self.class.name}##{__method__}: ignoring SIGTERM")
+    else
+      raise
+    end
   ensure
     reset_event_monitor_handle
   end

--- a/app/models/manageiq/providers/kubernetes/container_manager/kubernetes_event_monitor.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/kubernetes_event_monitor.rb
@@ -13,7 +13,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::KubernetesEventMonitor
   end
 
   def start
-    trap(:TERM) { $kube_log.info('EventMonitor#start: ignoring SIGTERM') }
     @inventory = nil
     @watcher = nil
   end


### PR DESCRIPTION
Since ruby 2.0, you cannot use a mutex in a trap context such as writing
a log message.

```
irb(main):001:0> require 'logger'
=> true
irb(main):002:0> trap(:TERM) { Logger.new("stdout").info "EventMonitor#start: ignoring SIGTERM" }
=> "DEFAULT"
irb(main):003:0> `kill #{Process.pid}`
log writing failed. can't be called from trap context
=> ""
```

Move this logic up to the caller of start and rescue a SignalException
with "SIGTERM" message instead.

See also: https://github.com/ManageIQ/manageiq/pull/2386

I wrote a "throwaway test" to verify this...it's not worth keeping
though:

```
diff --git a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
index 1dfbdfb..b51eaba 100644
--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -25,6 +25,17 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
     end
   end

+  describe "something" do
+    it "does things" do
+      MyClass = test_class
+      $kube_log = Logger.new("logger.log")
+      cm = test_class.new(ems)
+      handle = cm.event_monitor_handle
+      allow(handle).to receive(:start).and_raise(SignalException.new("SIGTERM"))
+      cm.monitor_events
+    end
+  end
+
   describe '#extract_event_data' do
     context 'given container event (Pod event with fieldPath)' do
       let(:kubernetes_event) do
```

Results in this:
```
08:51:14 ~/Code/manageiq-providers-kubernetes (cannot_log_in_trap_context) (2.4.1) + cat logger.log
I, [2017-08-17T08:45:30.523852 #51050]  INFO -- : MyClass#monitor_events: ignoring SIGTERM
```