### PR TITLE
Container Template: convert params to hashes

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/container_template_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_template_mixin.rb
@@ -10,7 +10,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplateMixin
                                             :namespace => project
                                           },
                                           :objects    => objects,
-                                          :parameters => params)
+                                          :parameters => params.collect(&:instantiation_attributes))
     create_objects(processed_template['objects'], project)
     @created_objects.each { |obj| obj[:miq_class] = model_by_entity(obj[:kind].underscore) }
   end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/15863

Converts the Container Template Parameters that are passed to instantiate method to hashes before passing them to openshift for template processing. The new hashes include only relevant attributes for instantiation instead of the whole active record object that has some irrelevant data. 

Moved from https://github.com/ManageIQ/manageiq/pull/15587