### PR TITLE
Container Template: Allow instantiation with object_labels

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/container_template_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_template_mixin.rb
@@ -2,15 +2,17 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplateMixin
   extend ActiveSupport::Concern
   include ManageIQ::Providers::Kubernetes::ContainerManager::EntitiesMapping
 
-  def instantiate(params, project = nil)
+  def instantiate(params, project = nil, labels = nil)
     project ||= container_project.name
+    labels  ||= object_labels
     processed_template = process_template(ext_management_system.connect,
                                           :metadata   => {
                                             :name      => name,
                                             :namespace => project
                                           },
                                           :objects    => objects,
-                                          :parameters => params.collect(&:instantiation_attributes))
+                                          :parameters => params.collect(&:instantiation_attributes),
+                                          :labels     => labels)
     create_objects(processed_template['objects'], project)
     @created_objects.each { |obj| obj[:miq_class] = model_by_entity(obj[:kind].underscore) }
   end


### PR DESCRIPTION
Extracted from: https://github.com/ManageIQ/manageiq/pull/15406

Allowing the `instantiate` method to receive labels as an argument so that each created object will be tagged with these labels during instantiation.

cc @moolitayer @simon3z 