### PR TITLE
Scanning::Job always cleanup all signals in cleanup

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -221,6 +221,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def cleanup(*args)
+    unqueue_all_signals
     image = target_entity
     if image
       # TODO: check job success / failure
@@ -251,8 +252,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     if self.state != "canceling" # ensure change of states
       signal :cancel
     else
-      unqueue_all_signals
-      queue_signal(:cancel_job)
+      signal :cancel_job
     end
   end
   alias_method :cancel_job, :cleanup

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -181,6 +181,16 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
       end
     end
 
+    context "when timeout occures during pod_wait state" do
+      it "should clean all signals and not fail in the state machine" do
+        initial_q_size = MiqQueue.all.count
+        MiqQueue.put(**@job.send(:queue_options), :args => [:pod_wait,])
+        expect(MiqQueue.all.count).to eq(initial_q_size + 1)
+        @job.cancel
+        expect(MiqQueue.all.count).to eq(initial_q_size)
+      end
+    end
+
     context "#current_job_timeout" do
       it "checks for timeout in Settings" do
         stub_settings_merge(:container_scanning => {:scanning_job_timeout => '15.minutes'})


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1481230

For reference, `unqueue_all_signals` is defined on the same file here: https://github.com/enoodle/manageiq-providers-kubernetes/blob/6bf8ad2a024c430207085e481c8e7c87643ed613/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb#L308