### PR TITLE
add authentication to image inspector requests

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -3,7 +3,7 @@ require 'kubeclient'
 
 class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   PROVIDER_CLASS = ManageIQ::Providers::Kubernetes::ContainerManager
-  INSPECTOR_IMAGE_TAG = '2.1'.freeze
+  INSPECTOR_IMAGE_TAG = '2.2'.freeze
   INSPECTOR_PORT = 8080
   DOCKER_SOCKET = '/var/run/docker.sock'
   SCAN_CATEGORIES = %w(system software)
@@ -14,6 +14,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   IMAGE_INSPECTOR_SA = 'inspector-admin'
   INSPECTOR_ADMIN_SECRET_PATH = '/var/run/secrets/kubernetes.io/inspector-admin-secret-'
   PROXY_ENV_VARIABLES = %w(no_proxy http_proxy https_proxy)
+  INSPECTOR_AUTH_TOKEN = "INSPECTOR_AUTH_TOKEN".freeze
 
   def load_transitions
     self.state ||= 'initializing'
@@ -53,7 +54,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
       :image_full_name => image.full_name,
       :pod_name        => "manageiq-img-scan-#{guid[0..4]}",
       :pod_port        => INSPECTOR_PORT,
-      :pod_namespace   => namespace
+      :pod_namespace   => namespace,
+      :auth_token      => SecureRandom.hex
     ))
 
     _log.info("Getting inspector-admin secret for pod [#{pod_full_name}]")
@@ -136,7 +138,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
       :pod_namespace => options[:pod_namespace],
       :pod_name      => options[:pod_name],
       :pod_port      => options[:pod_port],
-      :guest_os      => IMAGES_GUEST_OS
+      :guest_os      => IMAGES_GUEST_OS,
+      :auth_token    => auth_token
     }
 
     verify_error = verify_scanned_image_id(image_inspector_client.fetch_metadata)
@@ -287,7 +290,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
         :verify_ssl => ext_management_system.verify_ssl_mode,
         :cert_store => ext_management_system.ssl_cert_store
       },
-      :auth_options   => kubeclient.auth_options,
+      :auth_options   => kubeclient.auth_options.merge(:auth_token => auth_token),
       :http_proxy_uri => kubeclient.http_proxy_uri
     )
   end
@@ -351,6 +354,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def pod_definition(inspector_admin_secret_name)
+    pod_env = inspector_proxy_env_variables << { :name  => INSPECTOR_AUTH_TOKEN,
+                                                 :value => auth_token }
     pod_def = {
       :apiVersion => "v1",
       :kind       => "Pod",
@@ -391,13 +396,17 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
                 :name      => "docker-socket"
               }
             ],
-            :env             => inspector_proxy_env_variables,
+            :env             => pod_env,
             :readinessProbe  => {
               "initialDelaySeconds" => 15,
               "periodSeconds"       => 5,
               "httpGet"             => {
-                "path" => "/healthz",
-                "port" => options[:pod_port]
+                "path"        => "/healthz",
+                "port"        => options[:pod_port],
+                "httpHeaders" => {
+                  "name"  => "X-Auth-Token",
+                  "value" => auth_token
+                },
               }
             }
           }
@@ -448,5 +457,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     if ems_image_inspector_options.key?(:cve_url)
       pod_def[:spec][:containers][0][:command].append("--cve-url=#{ems_image_inspector_options[:cve_url]}")
     end
+  end
+
+  def auth_token
+    options[:auth_token]
   end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -231,9 +231,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
       :verify_mode => verify_ssl_mode,
       :cert_store  => ssl_cert_store,
     }
+    headers = client.headers
+    headers[:'X-Auth-Token'] = scan_data[:auth_token] if scan_data[:auth_token]
     MiqContainerGroup.new(pod_proxy + SCAN_CONTENT_PATH,
                           nethttp_options,
-                          client.headers.stringify_keys,
+                          headers.stringify_keys,
                           scan_data[:guest_os])
   end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -1,5 +1,17 @@
 require 'MiqContainerGroup/MiqContainerGroup'
 
+RSpec::Matchers.define :pod_env_containing do |expected|
+  match do |actual|
+    actual[:spec][:containers][0][:env][0][:name].include?(expected[:name]) && actual[:spec][:containers][0][:env][0][:value].include?(expected[:value])
+  end
+end
+
+RSpec::Matchers.define :hash_containing_string do |string|
+  match do |actual|
+    actual["args"] && actual["args"][0] && actual["args"][0].include?(string)
+  end
+end
+
 class MockKubeClient
   include ArrayRecursiveOpenStruct
 
@@ -161,10 +173,21 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
 
     context "completes successfully" do
       before(:each) do
+        allow(@job).to receive(:target_entity) { @image }
         allow_any_instance_of(described_class).to receive_messages(:collect_compliance_data) unless OpenscapResult.openscap_available?
 
         expect(@job.state).to eq 'waiting_to_start'
+        allow(Kubeclient::Resource).to receive(:new)
         @job.signal(:start)
+      end
+
+      it 'should create a pod spec with the auth_token environment variable' do
+        expect(Kubeclient::Resource).to have_received(:new).with(
+          pod_env_containing(
+            :name  => ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job::INSPECTOR_AUTH_TOKEN,
+            :value => @job.options[:auth_token]
+          )
+        )
       end
 
       it 'should report success' do
@@ -178,6 +201,14 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
         expect(@image.openscap_result).to be
         expect(@image.openscap_result.binary_blob.md5).to eq('d1f1857281573cd777b31d76e8529dc9')
         expect(@image.openscap_result.openscap_rule_results.count).to eq(213)
+      end
+
+      it 'should generate and store the image inspector auth_token' do
+        expect(@job.options[:auth_token]).not_to be_nil
+      end
+
+      it 'should pass the auth_token as a parameter to scan_metadata' do
+        expect(@image).to have_received(:scan_metadata).with(anything, hash_containing_string(@job.options[:auth_token]))
       end
     end
 


### PR DESCRIPTION
this PR leverages a new security feature in Image Inspector, which allows a custom authentication check using a shared secret.

The shared secret is initialized by passing the pod environment variable `INSPECTOR_AUTH_TOKEN`. HTTP requests send to the image inspector pod should be signed with the header `"X-Auth-Token"` whose value is the shared secret in order to authenticate.

Note that if Image Inspector does not find `INSPECTOR_AUTH_TOKEN` in the environment, it will skip performing this authentication check on HTTP requests.

This PR is a retry of #6, which failed Travis tests for unknown reasons.