### PR TITLE
Save persistent volume claim to project relation

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -189,6 +189,7 @@ module ManageIQ::Providers::Kubernetes
       process_collection(inventory["persistent_volume_claim"], key) { |n| parse_persistent_volume_claim(n) }
       @data[key].each do |pvc|
         @data_index.store_path(key, :by_namespace_and_name, pvc[:namespace], pvc[:name], pvc)
+        pvc[:project] = @data_index.fetch_path(path_for_entity("namespace"), :by_name, pvc[:namespace])
       end
     end
 
@@ -371,6 +372,7 @@ module ManageIQ::Providers::Kubernetes
 
       inv["persistent_volume_claim"].each do |pvc|
         h = parse_persistent_volume_claim(pvc)
+        h[:container_project] = lazy_find_project(:name => h[:namespace])
 
         collection.build(h)
       end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -473,6 +473,8 @@ shared_examples "kubernetes refresher VCR tests" do |check_tag_mapping: true|
         :phase    => "Bound",
         :capacity => {:storage => 10.gigabytes},
       )
+      expect(@bound_pvc.container_project.name).to eq("openshift-infra")
+
       pv = PersistentVolume.find_by(:name => "metrics-volume")
       cv = ContainerVolume.find_by(:name => "cassandra-data", :type => "ContainerVolume")
       expect(@bound_pvc.container_volumes).to contain_exactly(pv, cv)


### PR DESCRIPTION
depends on:
https://github.com/ManageIQ/manageiq-schema/pull/60
https://github.com/ManageIQ/manageiq/pull/15932

@cben @moolitayer @zakiva Please review
cc @simon3z we are going to need this relation for chargeback so we can identify pvc's that are not connected to pods but are connected to a project
