### PR TITLE
Add mising metrics authentication

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -130,6 +130,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   def authentications_to_validate
     at = [:bearer]
     at << :hawkular if has_authentication_type?(:hawkular)
+    at << :prometheus if has_authentication_type?(:prometheus)
     at
   end
 
@@ -165,7 +166,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   end
 
   def supported_auth_types
-    %w(default password bearer)
+    %w(default password bearer hawkular prometheus)
   end
 
   def supports_authentication?(authtype)


### PR DESCRIPTION
**Description**

Currently a miq queue request to authenticate a container provider will not authenticate all endpoints, missing endpoints are "hawkular" and "prometheus"

**Screenshots**
Before fix
![screenshot-5b7fd941-f833-4da3-bedb-5e20f2fd793d-2017-09-05-13-50-10](https://user-images.githubusercontent.com/2181522/30057959-94d71472-9241-11e7-902a-fed7f47368d2.png)

After fix
![screenshot-5b7fd941-f833-4da3-bedb-5e20f2fd793d-2017-09-05-13-49-43](https://user-images.githubusercontent.com/2181522/30057960-94d9c910-9241-11e7-8128-1895fa687205.png)

