### PR TITLE
Enable graph refresh (batch strategy) by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,7 +55,9 @@
 :ems_refresh:
   :kubernetes:
     :refresh_interval: 15.minutes
-    :inventory_object_refresh: false
+    :inventory_object_refresh: true
+    :inventory_collections:
+      :saver_strategy: :batch
 :workers:
   :worker_base:
     :event_catcher:


### PR DESCRIPTION
Same as https://github.com/ManageIQ/manageiq-providers-openshift/pull/48, can be merged in either order.

There are some loose ends (notably tag mapping missing)
but we want to get more testing from developers using it.

tracking issue #27
RFE https://bugzilla.redhat.com/show_bug.cgi?id=1470021