### PR TITLE
Fix net_usage_rate_average units

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -42,9 +42,9 @@ module ManageIQ::Providers
         :counter_key           => "net_usage_rate_average",
         :instance              => "",
         :capture_interval      => INTERVAL.to_s,
-        :precision             => 2,
+        :precision             => 1,
         :rollup                => "average",
-        :unit_key              => "datagramspersecond",
+        :unit_key              => "kilobytespersecond",
         :capture_interval_name => "realtime"
       }
     }


### PR DESCRIPTION
**Description**

We collect `average kb usage per second` from the external metrics data base.
When we insert data in the internal metrics data base we declare it to be 0.5 of `average datagrams per second`.

This may lead to wrong data presented to the end user, for example, if we collect 80 kb/sec the user may see 160 datagrams/sec [the *2 is for 0.5 to value conversion]

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1495733