### PR TITLE
Fail on creating scanning job with image instance

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -174,12 +174,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   end
 
   def raw_scan_job_create(target_class, target_id = nil, userid = nil, target_name = nil)
-    # maintain backward compatibility pre https://github.com/ManageIQ/manageiq/pull/13722
-    if target_class.kind_of?(ContainerImage)
-      target_id = target_class.id
-      target_name = target_class.name
-      target_class = target_class.class.name
-    end
+    raise MiqException::Error, _("target_class must be a class not an instance") if target_class.kind_of?(ContainerImage)
     userid ||= User.current_user.userid
     Job.create_job(
       "ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job",

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -173,13 +173,18 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     check_policy_prevent(:request_containerimage_scan, entity, User.current_user.userid, :raw_scan_job_create)
   end
 
-  def raw_scan_job_create(target_class, target_id = nil, userid = nil)
-    target_class, target_id = target_class.class.name, target_class.id if target_class.kind_of?(ContainerImage)
+  def raw_scan_job_create(target_class, target_id = nil, userid = nil, target_name = nil)
+    # maintain backward compatibility pre https://github.com/ManageIQ/manageiq/pull/13722
+    if target_class.kind_of?(ContainerImage)
+      target_id = target_class.id
+      target_name = target_class.name
+      target_class = target_class.class.name
+    end
     userid ||= User.current_user.userid
     Job.create_job(
       "ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job",
       :userid          => userid,
-      :name            => "Container image analysis",
+      :name            => "Container Image Analysis: '#{target_name}'",
       :target_class    => target_class,
       :target_id       => target_id,
       :zone            => my_zone,
@@ -197,7 +202,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
       :class_name  => self.class.to_s,
       :instance_id => id,
       :method_name => :check_policy_prevent_callback,
-      :args        => [cb_method, event_target.class.name, event_target.id, userid],
+      :args        => [cb_method, event_target.class.name, event_target.id, userid, event_target.name],
       :server_guid => MiqServer.my_guid
     }
     enforce_policy(event_target, policy_event, {}, { :miq_callback => cb }) unless policy_event.nil?

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -92,19 +92,11 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
         )
       end
 
-      it "Is backward compatible with #13722" do
-        # https://github.com/ManageIQ/manageiq/pull/13722
+      it "It should raise an error when creating a job with instance of Container Image" do
         image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
         User.current_user = FactoryGirl.create(:user, :userid => "bob")
-        job = @ems.raw_scan_job_create(image)
-        expect(job).to have_attributes(
-          :dispatch_status => "pending",
-          :state           => "waiting_to_start",
-          :status          => "ok",
-          :message         => "process initiated",
-          :target_class    => "ContainerImage",
-          :userid          => "bob"
-        )
+        expect { @ems.raw_scan_job_create(image) }
+          .to raise_error(MiqException::Error, "target_class must be a class not an instance")
       end
 
       it "Is backward compatible with #54" do


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/105. 

This PR removes the backward compatibility kept in https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/105. In case of creating a scanning job with image instance (instead of class) an explicit exception will be raised. 