### PR TITLE
adding cve_url and image_tag to global image_inspector settings

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/options.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/options.rb
@@ -33,12 +33,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::Options
             :repository  => {
               :label          => N_('Image-Inspector Repository'),
               :help_text      => N_('Image-Inspector Repository. example: openshift/image-inspector'),
-              :global_default => Settings.ems.ems_kubernetes.image_inspector_repository,
+              :global_default => ::Settings.ems.ems_kubernetes.image_inspector_repository,
             },
             :registry    => {
               :label          => N_('Image-Inspector Registry'),
               :help_text      => N_('Registry to provide the image inspector repository. example: docker.io'),
-              :global_default => Settings.ems.ems_kubernetes.image_inspector_registry,
+              :global_default => ::Settings.ems.ems_kubernetes.image_inspector_registry,
             },
             :image_tag   => {
               :label          => N_('Image-Inspector Tag'),
@@ -46,11 +46,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::Options
               :global_default => ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job::INSPECTOR_IMAGE_TAG,
             },
             :cve_url     => {
-              :label     => N_('CVE location'),
-              :help_text => N_('Enables defining a URL path prefix for XCCDF file instead of accessing the default location.
+              :label          => N_('CVE location'),
+              :help_text      => N_('Enables defining a URL path prefix for XCCDF file instead of accessing the default location.
   example: http://my_file_server.org:3333/xccdf_files/
   Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
               # Future versions of image inspector will extend this.
+              :global_default => ::Settings.ems.ems_kubernetes.image_inspector_cve_url,
             },
           }
         }

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -445,8 +445,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def add_cve_url(pod_def)
-    if ems_image_inspector_options.key?(:cve_url)
-      pod_def[:spec][:containers][0][:command].append("--cve-url=#{ems_image_inspector_options[:cve_url]}")
-    end
+    cve_url = ems_image_inspector_options.fetch_path(:cve_url) || ::Settings.ems.ems_kubernetes.image_inspector_cve_url
+    pod_def[:spec][:containers][0][:command].append("--cve-url=#{cve_url}") unless cve_url.blank?
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,7 @@
     :miq_namespace: management-infra
     :image_inspector_registry: docker.io
     :image_inspector_repository: openshift/image-inspector
+    :image_inspector_cve_url:
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:


### PR DESCRIPTION
This will use thes settings as global options when no per-provider options are set

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1459555