### PR TITLE
dont return an empty set when something goes wrong

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -68,7 +68,7 @@ module ManageIQ::Providers
         ems.try(:update_attributes,
                 :last_metrics_error       => :invalid,
                 :last_metrics_update_date => Time.now.utc)
-        return [{}, {}]
+        raise
       end
 
       Benchmark.realtime_block(:collect_data) do
@@ -78,7 +78,7 @@ module ManageIQ::Providers
           _log.error("Hawkular metrics service unavailable: #{e.message}")
           ems.update_attributes(:last_metrics_error       => :unavailable,
                                 :last_metrics_update_date => Time.now.utc) if ems
-          return [{}, {}]
+          raise
         end
       end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -25,19 +25,19 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
   end
 
   context "#perf_collect_metrics" do
-    it "fails quietly when no ems is defined" do
+    it "fails when no ems is defined" do
       @node.ext_management_system = nil
-      expect(@node.perf_collect_metrics('interval_name')).to eq([{}, {}])
+      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(described_class::TargetValidationError)
     end
 
-    it "fails quietly when no cpu cores are defined" do
+    it "fails when no cpu cores are defined" do
       @node.hardware.cpu_total_cores = nil
-      expect(@node.perf_collect_metrics('interval_name')).to eq([{}, {}])
+      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(described_class::TargetValidationError)
     end
 
-    it "fails quietly when memory is not defined" do
+    it "fails when memory is not defined" do
       @node.hardware.memory_mb = nil
-      expect(@node.perf_collect_metrics('interval_name')).to eq([{}, {}])
+      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(described_class::TargetValidationError)
     end
 
     # TODO: include also sort_and_normalize in the tests


### PR DESCRIPTION
an empty set means there is no data and the platform will not
try to collect the data again. Unless a manual gap detection is
performed.

see https://github.com/ManageIQ/manageiq/blob/91d3ef4189e8b9e9d2225b758082d52f688926da/app/models/metric/ci_mixin/capture.rb#L193-L195
and
https://github.com/ManageIQ/manageiq/blob/91d3ef4189e8b9e9d2225b758082d52f688926da/app/models/metric/ci_mixin/capture.rb#L56-L58

fixes
https://bugzilla.redhat.com/show_bug.cgi?id=1411894

@yaacov please have a look if that makes sense for you
cc @agrare 