### PR TITLE
Prefix ems_ref with object type in event hash

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/event_parser_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_parser_mixin.rb
@@ -4,7 +4,16 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventParserMixin
   included do
     def self.event_to_hash(event, ems_id = nil)
       _log.debug("ems_id: [#{ems_id}] event: [#{event.inspect}]")
-      {
+      ems_ref_key = case event[:kind]
+                    when 'Node'
+                      :container_node_ems_ref
+                    when 'Pod'
+                      :container_group_ems_ref
+                    when 'ReplicationController'
+                      :container_replicator_ems_ref
+                    end
+
+      event_hash = {
         :event_type                => event[:event_type],
         :source                    => 'KUBERNETES',
         :timestamp                 => event[:timestamp],
@@ -14,10 +23,13 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventParserMixin
         :container_replicator_name => event[:container_replicator_name],
         :container_namespace       => event[:container_namespace],
         :container_name            => event[:container_name],
-        :ems_ref                   => event[:uid],
         :full_data                 => event,
         :ems_id                    => ems_id
       }
+
+      event_hash[ems_ref_key] = event[:uid]
+
+      event_hash
     end
   end
 end


### PR DESCRIPTION
The event handler expects the ems_ref to be prefixed by the object type,
not using the raw ems_ref.  This is causing issues adding a real ems_ref
for an event because the process_container_entities_in_event! method is
clearing the key.