### PR TITLE
Require 'faraday_middleware' in monitoring_manager_mixin.rb

### DIFF
--- a/app/models/manageiq/providers/kubernetes/monitoring_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/monitoring_manager_mixin.rb
@@ -1,3 +1,5 @@
+require 'faraday_middleware'
+
 module ManageIQ::Providers::Kubernetes::MonitoringManagerMixin
   extend ActiveSupport::Concern
   ENDPOINT_ROLE = :prometheus_alerts

--- a/spec/models/manageiq/providers/kubernetes/monitoring_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/monitoring_manager_spec.rb
@@ -41,6 +41,7 @@ describe ManageIQ::Providers::Kubernetes::MonitoringManager do
         described_class.name.underscore,
         # :record => :new_episodes,
       ) do
+        # in case of error try to check monitoring_manager.authentication_check
         expect(monitoring_manager.authentication_status_ok?).to be_falsey
         monitoring_manager.authentication_check_types
         expect(monitoring_manager.authentication_status_ok?).to be_truthy


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/131

Test in `spec/models/manageiq/providers/kubernetes/monitoring_manager_spec.rb` fails since the require statement was removed from the main repo in https://github.com/ManageIQ/manageiq/pull/16024, so we should require it in this repo.  