### PR TITLE
Use new ContainerLabelTagMapping::Mapper interface

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -18,7 +18,8 @@ module ManageIQ::Providers::Kubernetes
 
       @data = {}
       @data_index = {}
-      @label_tag_mapping = ContainerLabelTagMapping.cache
+      @tag_mapper = ContainerLabelTagMapping.mapper
+      @data[:tag_mapper] = @tag_mapper
     end
 
     def ems_inv_to_hashes(inventory, _options = Config::Options.new)
@@ -595,7 +596,7 @@ module ManageIQ::Providers::Kubernetes
     ## Shared parsing methods
 
     def map_labels(model_name, labels)
-      ContainerLabelTagMapping.map_labels(@label_tag_mapping, model_name, labels)
+      @tag_mapper.map_labels(model_name, labels)
     end
 
     def find_host_by_provider_id(provider_id)


### PR DESCRIPTION
Overview/plan issue: ManageIQ/manageiq-providers-kubernetes#126

To be merged **simultaneously** with https://github.com/ManageIQ/manageiq/pull/16098 & https://github.com/ManageIQ/manageiq-providers-amazon/pull/316.  Can't pass Travis until the core PR lands.

Expose mapper to save_inventory_container which will use it to find/create all referenced tags.