### PR TITLE
Changed interface for post refresh

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
@@ -20,9 +20,8 @@ module ManageIQ
           end
         end
 
-        def manager_refresh_post_processing(_ems, _target, inventory_collections)
-          indexed = inventory_collections.index_by(&:name)
-          container_images_post_processing(indexed[:container_images])
+        def manager_refresh_post_processing(_ems, _target, persister)
+          container_images_post_processing(persister.container_images)
         end
 
         def container_images_post_processing(container_images)


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/16280
- [ ] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/135

Changed interface for post refresh in core, we pass Persister object
instead of Array<InventoryCollection>