### PR TITLE
Collect ems targeted Prometheus events

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -263,4 +263,10 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
       )
     end
   end
+
+  def evaluate_alert(_alert_id, _event)
+    # currently only EmsEvents from Prometheus are tested for node alerts,
+    # and these should automatically be translated to alerts.
+    true
+  end
 end

--- a/spec/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher/runner_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher/runner_mixin_spec.rb
@@ -46,23 +46,29 @@ describe ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::Runne
   end
 
   let(:monitoring_manager) { container_manager.monitoring_manager }
+  let(:node_annotations) { {"miqTarget" => 'ContainerNode'} }
 
   context "#find_target" do
     it "finds a target container node" do
-      target = FactoryGirl.create(:container_node)
+      target = FactoryGirl.create(:container_node, :name => 'testing')
       labels = {
         "instance" => target.name
       }
-      expect(subject.find_target(labels)).to eq(target)
+      expect(subject.find_target(node_annotations, labels)).to eq(
+        :container_node_name => target.name,
+        :container_node_id   => target.id,
+        :target_type         => "ContainerNode",
+        :target_id           => target.id,
+      )
     end
 
     it "logs error and returns nil if the node does not exist" do
-      target = FactoryGirl.build(:container_node)
+      target = FactoryGirl.build(:container_node, :name => 'testing')
       labels = {
         "instance" => target.name
       }
       expect($cn_monitoring_log).to receive(:error)
-      expect(subject.find_target(labels)).to eq(nil)
+      expect(subject.find_target(node_annotations, labels).compact).to eq(:container_node_name => target.name)
     end
   end
 

--- a/spec/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher/stream_spec.rb
@@ -55,6 +55,7 @@ describe ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::Strea
         [
           FactoryGirl.create(
             :ems_event,
+            :source                => "DATAWAREHOUSE",
             :timestamp             => "1970-01-01 00:00:00.000000",
             :ext_management_system => container_manager,
             :full_data             => {
@@ -65,6 +66,7 @@ describe ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::Strea
           # not real data because this generation also need a 0 index, but good for the test purpose
           FactoryGirl.create(
             :ems_event,
+            :source                => "DATAWAREHOUSE",
             :timestamp             => "1970-01-02 00:00:00.000000",
             :ext_management_system => container_manager,
             :full_data             => {


### PR DESCRIPTION
- Enable alerts on the new events
- Dropped the timestamp hack (no longer needed after https://github.com/ManageIQ/manageiq/pull/16104)

Part of Prometheus Alert integration:
https://github.com/ManageIQ/manageiq/issues/14238

Related to
https://github.com/ManageIQ/manageiq/pull/16310