### PR TITLE
Fix non-standard `have_attributes` usage warnings

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -397,7 +397,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
       parsed_volumes = parser.send(:parse_volumes, pod)
 
       example_volumes.zip(parsed_volumes).each do |example, parsed|
-        expect(parsed).to have_attributes(
+        expect(parsed).to include(
           :name                  => example[:name],
           :git_repository        => example[:git_repository],
           :empty_dir_medium_type => example[:empty_dir_medium_type],


### PR DESCRIPTION
ManageIQ has its own `have_attributes` which has diverged from upstream rspec's.  It'll go away at some point.
This fixes one non-standard usage this repo had.
(Thanks to https://github.com/ManageIQ/manageiq/pull/16188 warnings)

before: https://travis-ci.org/ManageIQ/manageiq-providers-kubernetes/jobs/294409726
after: https://travis-ci.org/cben/manageiq-providers-kubernetes/jobs/294618442

providers-openshift repo is clean.

@miq-bot add-labels test, technical debt