### PR TITLE
Make sure targeted refresh does not duplicate entities

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
@@ -372,8 +372,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
           inventory_object = inventory_objects_index.delete(index)
           hash             = attributes_index.delete(index)
 
-          # Make the entity active again
-          hash[:deleted_on] = nil unless hash.key?(:deleted_on)
+          # Make the entity active again, otherwise we would be duplicating nested entities
+          hash[:deleted_on] = nil
 
           record.assign_attributes(hash.except(:id, :type))
           if !inventory_collection.check_changed? || record.changed?

--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
@@ -365,7 +365,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
       raise "Allowed only manager_ref size of 1, got #{inventory_collection.manager_ref}" if inventory_collection.manager_ref.count > 1
 
       inventory_objects_index.each_slice(1000) do |batch|
-        relation.where(inventory_collection.manager_ref.first => batch.map(&:second).map(&:manager_uuid)).each do |record|
+        relation.where(inventory_collection.manager_ref.first => batch.map(&:first)).each do |record|
           index = inventory_collection.object_index_with_keys(inventory_collection.manager_ref_to_cols, record)
 
           # We need to delete the record from the inventory_objects_index and attributes_index, otherwise it


### PR DESCRIPTION
Make sure targeted refresh does not duplicate entities by implementing the reconnect logic for ContainerGroup, Container and ContainerImage models.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1507899

Fixes issue:
https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/103