### PR TITLE
Prometheus Alert flow changes

### DIFF
--- a/app/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher/stream.rb
@@ -69,9 +69,7 @@ class ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::Stream
   end
 
   def alert_for_miq?(alert)
-    %w(ContainerNode ExtManagementSystem).include?(
-      alert.fetch_path("annotations", "miqTarget")
-    )
+    alert.fetch_path("annotations", "miqIgnore").to_s.downcase != "true"
   end
 
   def last_position


### PR DESCRIPTION
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1507990

Currently ManageIQ collects alerts with annotation `MiqTarget=ContainerNode|ExtManagementSystem` and uses the annotation to find the target object.
Suggested: ManageIQ collects all generated alerts[1] and always attaches incoming alerts to the ems

Note: a user can still specify `MiqTarget=ContainerNode` to attach a specific alert to a node.
- If the node cannot be found for some reason,  the alert will fallback on the ext.
- There should never be a mismatch, even if we have a Node alerts with several firing instances defined on the same node (e.g one instance for each container in the node).
  The screen would show them as duplicated alerts.

[1] you can still ignore alerts by annotating them with `miqIgnore=true`
