### PR TITLE
Make sure we save last occurrence of watch pod

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/target_collection_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/target_collection_mixin.rb
@@ -37,7 +37,9 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::TargetCollectionMixin
   end
 
   def pod_list
-    target.targets.map { |target| JSON.parse(target.options[:payload], :object_class => OpenStruct) }
+    targets = target.targets.map { |target| JSON.parse(target.options[:payload], :object_class => OpenStruct) }
+    # Return only the latest occurrence of each pod
+    targets.index_by { |x| x.metadata.uid }.values
   end
 
   private

--- a/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -223,7 +223,11 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
 
   def assert_specific_container
     # Test added Container
-    @container = Container.find_by(:ems_ref => "1b641a4f-aa70-11e7-8a08-001a4a162711_stress4_docker.io/fsimonce/stress-test")
+    container_ems_ref = "1b641a4f-aa70-11e7-8a08-001a4a162711_stress4_docker.io/fsimonce/stress-test"
+    containers_count = Container.where(:ems_ref => container_ems_ref).count
+    expect(containers_count).to eq 1
+
+    @container = Container.find_by(:ems_ref => container_ems_ref)
     expect(@container).to have_attributes(
       :name          => "stress4",
       :restart_count => 0,
@@ -246,7 +250,11 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
     )
 
     # Test deleted Container
-    @container_deleted = Container.find_by(:ems_ref => "06cff57b-bf0c-11e7-a73f-001a4a162711_stress6_docker.io/fsimonce/stress-test")
+    container_ems_ref = "06cff57b-bf0c-11e7-a73f-001a4a162711_stress6_docker.io/fsimonce/stress-test"
+    containers_count = Container.where(:ems_ref => container_ems_ref).count
+    expect(containers_count).to eq 1
+
+    @container_deleted = Container.find_by(:ems_ref => container_ems_ref)
     expect(@container_deleted).to have_attributes(
       :name          => "stress6",
       :restart_count => 0,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -280,12 +280,19 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
   end
 
   def assert_specific_container_group
-    @containergroup = ContainerGroup.find_by(:name => "stress4-1-7r2fb")
-    expect(@containergroup).to have_attributes(
-      :name           => "stress4-1-7r2fb",
-      :restart_policy => "Always",
-      :dns_policy     => "ClusterFirst",
-      :deleted_on     => nil
+    # Test added Pod
+    container_group_name  = "stress4-1-7r2fb"
+    container_group_count = ContainerGroup.where(:name => container_group_name).count
+    expect(container_group_count).to eq 1
+
+    @containergroup = ContainerGroup.find_by(:name => container_group_name)
+    expect(@containergroup).to(
+      have_attributes(
+        :name           => container_group_name,
+        :restart_policy => "Always",
+        :dns_policy     => "ClusterFirst",
+        :deleted_on     => nil
+      )
     )
 
     # Check the relation to container node
@@ -297,6 +304,35 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
     expect(@containergroup.containers.count).to eq(1)
     expect(@containergroup.containers.last).to have_attributes(
       :name => "stress4"
+    )
+
+    expect(@containergroup.container_project).to eq(ContainerProject.find_by(:name => "vcr-tests"))
+    expect(@containergroup.ext_management_system).to eq(@ems)
+
+    # Test deleted Pod
+    container_group_name  = "stress6-1-42svr"
+    container_group_count = ContainerGroup.where(:name => container_group_name).count
+    expect(container_group_count).to eq 1
+
+    @containergroup = ContainerGroup.find_by(:name => container_group_name)
+    expect(@containergroup).to(
+      have_attributes(
+        :name           => container_group_name,
+        :restart_policy => "Always",
+        :dns_policy     => "ClusterFirst",
+        :deleted_on     => nil
+      )
+    )
+
+    # Check the relation to container node
+    expect(@containergroup.container_node).to have_attributes(
+      :name => "ladislav-ocp-3.6-compute04.10.35.49.24.nip.io"
+    )
+
+    # Check the relation to containers
+    expect(@containergroup.containers.count).to eq(1)
+    expect(@containergroup.containers.last).to have_attributes(
+      :name => "stress6"
     )
 
     expect(@containergroup.container_project).to eq(ContainerProject.find_by(:name => "vcr-tests"))

--- a/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -233,6 +233,7 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
       :restart_count => 0,
       :started_at    => "2017-10-06 08:27:00.000000000 +0000",
       :finished_at   => nil,
+      :deleted_on    => nil
     )
     expect(@container[:backing_ref]).not_to be_nil
 
@@ -260,6 +261,7 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
       :restart_count => 0,
       :started_at    => "2017-11-01 13:53:29.000000000 +0000",
       :finished_at   => "2017-11-01 15:11:42.000000000 +0000",
+      :deleted_on    => nil
     )
     expect(@container_deleted[:backing_ref]).not_to be_nil
 
@@ -283,6 +285,7 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
       :name           => "stress4-1-7r2fb",
       :restart_policy => "Always",
       :dns_policy     => "ClusterFirst",
+      :deleted_on     => nil
     )
 
     # Check the relation to container node
@@ -361,6 +364,7 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
   def assert_specific_used_container_image
     @container_image = ContainerImage.find_by(:name => "fsimonce/stress-test")
 
+    expect(@container_image.deleted_on).to be_nil
     expect(@container_image.ext_management_system).to eq(@ems)
     expect(@container_image.environment_variables.count).to eq(0)
     # TODO: for next recording, oc label some running, openshift-built image

--- a/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/watch_pod_stress_6_deleted.json
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/watch_pod_stress_6_deleted.json
@@ -1,0 +1,150 @@
+{
+  "type": "DELETED",
+  "object": {
+    "kind": "Pod",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "stress6-1-42svr",
+      "generateName": "stress6-1-",
+      "namespace": "vcr-tests",
+      "selfLink": "/api/v1/namespaces/vcr-tests/pods/stress6-1-42svr",
+      "uid": "06cff57b-bf0c-11e7-a73f-001a4a162711",
+      "resourceVersion": "2515564",
+      "creationTimestamp": "2017-11-01T13:53:23Z",
+      "deletionTimestamp": "2017-11-01T15:11:42Z",
+      "deletionGracePeriodSeconds": 0,
+      "labels": {
+        "deployment": "stress6-1",
+        "deploymentconfig": "stress6",
+        "run": "stress6"
+      },
+      "annotations": {
+        "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"vcr-tests\",\"name\":\"stress6-1\",\"uid\":\"0aab42e9-b4ce-11e7-8a08-001a4a162711\",\"apiVersion\":\"v1\",\"resourceVersion\":\"2508828\"}}\n",
+        "openshift.io/deployment-config.latest-version": "1",
+        "openshift.io/deployment-config.name": "stress6",
+        "openshift.io/deployment.name": "stress6-1",
+        "openshift.io/scc": "restricted"
+      },
+      "ownerReferences": [
+        {
+          "apiVersion": "v1",
+          "kind": "ReplicationController",
+          "name": "stress6-1",
+          "uid": "0aab42e9-b4ce-11e7-8a08-001a4a162711",
+          "controller": true,
+          "blockOwnerDeletion": true
+        }
+      ]
+    },
+    "spec": {
+      "volumes": [
+        {
+          "name": "default-token-78s93",
+          "secret": {
+            "secretName": "default-token-78s93",
+            "defaultMode": 420
+          }
+        }
+      ],
+      "containers": [
+        {
+          "name": "stress6",
+          "image": "docker.io/fsimonce/stress-test",
+          "resources": {},
+          "volumeMounts": [
+            {
+              "name": "default-token-78s93",
+              "readOnly": true,
+              "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+            }
+          ],
+          "terminationMessagePath": "/dev/termination-log",
+          "terminationMessagePolicy": "File",
+          "imagePullPolicy": "Always",
+          "securityContext": {
+            "capabilities": {
+              "drop": [
+                "KILL",
+                "MKNOD",
+                "SETGID",
+                "SETUID",
+                "SYS_CHROOT"
+              ]
+            },
+            "privileged": false,
+            "seLinuxOptions": {
+              "level": "s0:c11,c10"
+            },
+            "runAsUser": 1000130000
+          }
+        }
+      ],
+      "restartPolicy": "Always",
+      "terminationGracePeriodSeconds": 30,
+      "dnsPolicy": "ClusterFirst",
+      "serviceAccountName": "default",
+      "serviceAccount": "default",
+      "nodeName": "ladislav-ocp-3.6-compute04.10.35.49.24.nip.io",
+      "securityContext": {
+        "seLinuxOptions": {
+          "level": "s0:c11,c10"
+        },
+        "fsGroup": 1000130000
+      },
+      "imagePullSecrets": [
+        {
+          "name": "default-dockercfg-l2ng9"
+        }
+      ],
+      "schedulerName": "default-scheduler"
+    },
+    "status": {
+      "phase": "Running",
+      "conditions": [
+        {
+          "type": "Initialized",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2017-11-01T13:53:23Z"
+        },
+        {
+          "type": "Ready",
+          "status": "False",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2017-11-01T15:11:42Z",
+          "reason": "ContainersNotReady",
+          "message": "containers with unready status: [stress6]"
+        },
+        {
+          "type": "PodScheduled",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2017-11-01T13:53:23Z"
+        }
+      ],
+      "hostIP": "10.35.49.22",
+      "startTime": "2017-11-01T13:53:23Z",
+      "containerStatuses": [
+        {
+          "name": "stress6",
+          "state": {
+            "terminated": {
+              "exitCode": 0,
+              "reason": "Completed",
+              "startedAt": "2017-11-01T13:53:29Z",
+              "finishedAt": "2017-11-01T15:11:42Z",
+              "containerID": "docker://11ab4e0f5cad6d21f6371a50290ea039e5b796da81eda82142d78389f246c906"
+            }
+          },
+          "lastState": {},
+          "ready": false,
+          "restartCount": 0,
+          "image": "docker.io/fsimonce/stress-test:latest",
+          "imageID": "docker-pullable://docker.io/fsimonce/stress-test@sha256:baa95d9848ec0608803cc2a18f0b9b55c967a8ed6dea62fb0d045cb6b7bfb32a",
+          "containerID": "docker://11ab4e0f5cad6d21f6371a50290ea039e5b796da81eda82142d78389f246c906"
+        }
+      ],
+      "qosClass": "BestEffort"
+    }
+  }
+}

--- a/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/watch_pod_stress_6_modified.json
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/watch_pod_stress_6_modified.json
@@ -1,0 +1,145 @@
+{
+  "type": "MODIFIED",
+  "object": {
+    "kind": "Pod",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "stress6-1-42svr",
+      "generateName": "stress6-1-",
+      "namespace": "vcr-tests",
+      "selfLink": "/api/v1/namespaces/vcr-tests/pods/stress6-1-42svr",
+      "uid": "06cff57b-bf0c-11e7-a73f-001a4a162711",
+      "resourceVersion": "2515548",
+      "creationTimestamp": "2017-11-01T13:53:23Z",
+      "deletionTimestamp": "2017-11-01T15:12:12Z",
+      "deletionGracePeriodSeconds": 30,
+      "labels": {
+        "deployment": "stress6-1",
+        "deploymentconfig": "stress6",
+        "run": "stress6"
+      },
+      "annotations": {
+        "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"vcr-tests\",\"name\":\"stress6-1\",\"uid\":\"0aab42e9-b4ce-11e7-8a08-001a4a162711\",\"apiVersion\":\"v1\",\"resourceVersion\":\"2508828\"}}\n",
+        "openshift.io/deployment-config.latest-version": "1",
+        "openshift.io/deployment-config.name": "stress6",
+        "openshift.io/deployment.name": "stress6-1",
+        "openshift.io/scc": "restricted"
+      },
+      "ownerReferences": [
+        {
+          "apiVersion": "v1",
+          "kind": "ReplicationController",
+          "name": "stress6-1",
+          "uid": "0aab42e9-b4ce-11e7-8a08-001a4a162711",
+          "controller": true,
+          "blockOwnerDeletion": true
+        }
+      ]
+    },
+    "spec": {
+      "volumes": [
+        {
+          "name": "default-token-78s93",
+          "secret": {
+            "secretName": "default-token-78s93",
+            "defaultMode": 420
+          }
+        }
+      ],
+      "containers": [
+        {
+          "name": "stress6",
+          "image": "docker.io/fsimonce/stress-test",
+          "resources": {},
+          "volumeMounts": [
+            {
+              "name": "default-token-78s93",
+              "readOnly": true,
+              "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+            }
+          ],
+          "terminationMessagePath": "/dev/termination-log",
+          "terminationMessagePolicy": "File",
+          "imagePullPolicy": "Always",
+          "securityContext": {
+            "capabilities": {
+              "drop": [
+                "KILL",
+                "MKNOD",
+                "SETGID",
+                "SETUID",
+                "SYS_CHROOT"
+              ]
+            },
+            "privileged": false,
+            "seLinuxOptions": {
+              "level": "s0:c11,c10"
+            },
+            "runAsUser": 1000130000
+          }
+        }
+      ],
+      "restartPolicy": "Always",
+      "terminationGracePeriodSeconds": 30,
+      "dnsPolicy": "ClusterFirst",
+      "serviceAccountName": "default",
+      "serviceAccount": "default",
+      "nodeName": "ladislav-ocp-3.6-compute04.10.35.49.24.nip.io",
+      "securityContext": {
+        "seLinuxOptions": {
+          "level": "s0:c11,c10"
+        },
+        "fsGroup": 1000130000
+      },
+      "imagePullSecrets": [
+        {
+          "name": "default-dockercfg-l2ng9"
+        }
+      ],
+      "schedulerName": "default-scheduler"
+    },
+    "status": {
+      "phase": "Running",
+      "conditions": [
+        {
+          "type": "Initialized",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2017-11-01T13:53:23Z"
+        },
+        {
+          "type": "Ready",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2017-11-01T13:53:30Z"
+        },
+        {
+          "type": "PodScheduled",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2017-11-01T13:53:23Z"
+        }
+      ],
+      "hostIP": "10.35.49.22",
+      "podIP": "10.128.2.25",
+      "startTime": "2017-11-01T13:53:23Z",
+      "containerStatuses": [
+        {
+          "name": "stress6",
+          "state": {
+            "running": {
+              "startedAt": "2017-11-01T13:53:29Z"
+            }
+          },
+          "lastState": {},
+          "ready": true,
+          "restartCount": 0,
+          "image": "docker.io/fsimonce/stress-test:latest",
+          "imageID": "docker-pullable://docker.io/fsimonce/stress-test@sha256:baa95d9848ec0608803cc2a18f0b9b55c967a8ed6dea62fb0d045cb6b7bfb32a",
+          "containerID": "docker://11ab4e0f5cad6d21f6371a50290ea039e5b796da81eda82142d78389f246c906"
+        }
+      ],
+      "qosClass": "BestEffort"
+    }
+  }
+}


### PR DESCRIPTION
Make sure we save last occurrence of watch pod. The last occurrence  is having the finished_at date. Right now, we were saving the first occurrence, thanks to using .build method (which returns existing InventoryObject if there are duplicates)