### PR TITLE
Add a setting to only send DELETED notices

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collector_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collector_mixin.rb
@@ -100,6 +100,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollectorMixi
   def watch_thread
     pod_watch_stream.each do |notice|
       break if exit_requested
+      next if notice.type != "DELETED" && worker_settings[:deleted_notices_only]
 
       _log.info("EMS [#{ems.id}] Received change for pod [#{parse_notice_pod_ems_ref(notice.object)}]")
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,6 +70,7 @@
         :poll: 20.seconds
     :ems_inventory_collector_worker:
       :ems_inventory_collector_worker_kubernetes:
+        :deleted_notices_only: true
         :disabled: false
         :watch_thread_shutdown_timeout: 10.seconds
     :queue_worker_base:


### PR DESCRIPTION
This adds a setting to the InventoryCollectorWorker which allows for only DELETED pod notices to be sent, thus reducing the traffic hitting MiqQueue.