### PR TITLE
Prometheus unavailable alert

### DIFF
--- a/app/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher/stream.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::Stream
   def initialize(ems)
     @ems = ems
+    @current_generation = nil
+    @open_incident = nil
   end
 
   def start
@@ -20,10 +22,10 @@ class ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::Stream
   end
 
   def fetch
-    unless @current_generation
-      @current_generation, @current_index = last_position
-    end
+    check_state
     $cn_monitoring_log.info("Fetching alerts. Generation: [#{@current_generation}/#{@current_index}]")
+    alert_list, error = poll_messages
+    return [error] if error
 
     # {
     #   "generationID":"323e0863-f501-4896-b7dc-353cf863597d",
@@ -38,8 +40,13 @@ class ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::Stream
     #   ...
     #   ]
     # }
-    alert_list = @ems.connect.get(:generation_id => @current_generation, :from_index => @current_index)
     alerts = []
+
+    if collection_incident_ongoing?
+      alerts << resolve_collection_incident
+      $cn_monitoring_log.info("[#{@ems.name}] collection problem resolved")
+    end
+
     @current_generation = alert_list["generationID"]
     return alerts if alert_list['messages'].blank?
     alert_list["messages"].each do |message|
@@ -56,6 +63,28 @@ class ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::Stream
     $cn_monitoring_log.info("[#{alerts.size}] new alerts. New generation: [#{@current_generation}/#{@current_index}]")
     $cn_monitoring_log.debug(alerts)
     alerts
+  end
+
+  def check_state
+    unless @current_generation # first run of worker, check if there is a position from previous run
+      @current_generation, @current_index = last_position
+    end
+    unless @open_incident
+      @open_incident = incident_custom_attribute
+    end
+  end
+
+  def poll_messages
+    response = @ems.connect.get(:generation_id => @current_generation, :from_index => @current_index)
+    [response, nil]
+  rescue Faraday::ClientError => err
+    if collection_incident_ongoing?
+      raise
+    else
+      $cn_monitoring_log.error("[#{@ems.name}] collection problem initiated")
+      $cn_monitoring_log.error(err)
+      [nil, initiate_collection_incident]
+    end
   end
 
   def process_alert!(alert, generation, group_index)
@@ -76,5 +105,53 @@ class ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::Stream
       last_event.full_data['generationID'].to_s,
       last_index ? last_index + 1 : 0
     ]
+  end
+
+  def collection_incident_ongoing?
+    !@open_incident.value.nil?
+  end
+
+  def initiate_collection_incident
+    @open_incident.update_attributes(:value => Time.zone.now)
+    incident_event(@open_incident.value, true)
+  end
+
+  #
+  # Emit a simulated Prometheus EmsEvent that can trigger an alert
+  #
+  def resolve_collection_incident
+    initiation_time = @open_incident.value
+    @open_incident.update_attributes(:value => nil)
+    incident_event(initiation_time, false)
+  end
+
+  #
+  # @returns Emit a simulated Prometheus EmsEvent that can trigger an alert
+  #
+  def incident_event(incident_start, firing)
+    {
+      "annotations"  => {
+        "url"       => "www.example.com",
+        "severity"  => "error",
+        "miqTarget" => "ExtManagementSystem",
+        "message"   => "Event Collection Problem",
+        "UUID"      => "bde8a18c-913c-4b15-ba55-a1ca49b6674f",
+      },
+      "labels"       => {},
+      "startsAt"     => incident_start,
+      "status"       => firing ? "firing" : "resolved",
+      "generationID" => @current_generation,
+      "index"        => @current_index,
+    }
+  end
+
+  def incident_custom_attribute
+    CustomAttribute.find_or_create_by(
+      :section     => "event_stream_state",
+      :name        => "active_incident_start_date",
+      :description => "Error in prometheus collection",
+      :resource    => @ems,
+      :source      => "ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::Stream",
+    )
   end
 end


### PR DESCRIPTION
Contains part of https://github.com/ManageIQ/manageiq/issues/16395

The PR will catch the most common cases where Prometheus is unavailable/returns unexpected response. It won't catch errors where the platform does not start the collector - e.g auth failure. When the collection returns to normal, the alert should resolve. This allows seeing alerts in the monitoring screen when Prometheus is unavailable.