### PR TITLE
disable collector worker for now

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -71,7 +71,7 @@
     :ems_inventory_collector_worker:
       :ems_inventory_collector_worker_kubernetes:
         :deleted_notices_only: true
-        :disabled: false
+        :disabled: true
         :watch_thread_shutdown_timeout: 10.seconds
     :queue_worker_base:
         :ems_metrics_collector_worker:


### PR DESCRIPTION
We want to disable the k8s collector worker for now. It is generating sql statements that are too big for postgres to handle

The data is quite large. 0.5Gb
It is blowing up miq_queue table and pg memory

```
PG::OutOfMemory: ERROR:  out of memory
DETAIL:  Failed on request of size 536,870,912.
: UPDATE "miq_queue" SET "msg_data" = '\x0...'
```