### PR TITLE
Tag mapping in graph refresh

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -1,7 +1,5 @@
 # instantiated at the end, for both classical and graph refresh
-shared_examples "kubernetes refresher VCR tests" do |check_tag_mapping: true|
-  let(:check_tag_mapping) { check_tag_mapping }
-
+shared_examples "kubernetes refresher VCR tests" do
   before(:each) do
     allow(MiqServer).to receive(:my_zone).and_return("default")
     auth = AuthToken.new(:name => "test", :auth_key => "valid-token")
@@ -155,12 +153,10 @@ shared_examples "kubernetes refresher VCR tests" do |check_tag_mapping: true|
     expect(@containergroup.labels).to contain_exactly(
       label_with_name_value("name", "heapster")
     )
-    if check_tag_mapping
-      expect(@containergroup.tags).to contain_exactly(
-        tag_in_category_with_description(@name_category, "heapster"),
-        *expected_extra_tags
-      )
-    end
+    expect(@containergroup.tags).to contain_exactly(
+      tag_in_category_with_description(@name_category, "heapster"),
+      *expected_extra_tags
+    )
 
     # Check the relation to container node
     expect(@containergroup.container_node).not_to be_nil
@@ -295,12 +291,10 @@ shared_examples "kubernetes refresher VCR tests" do |check_tag_mapping: true|
     expect(@replicator.labels).to contain_exactly(
       label_with_name_value("name", "influxGrafana")
     )
-    if check_tag_mapping
-      expect(@replicator.tags).to contain_exactly(
-        tag_in_category_with_description(@name_category, "influxGrafana"),
-        *expected_extra_tags
-      )
-    end
+    expect(@replicator.tags).to contain_exactly(
+      tag_in_category_with_description(@name_category, "influxGrafana"),
+      *expected_extra_tags
+    )
     expect(@replicator.selector_parts.count).to eq(1)
 
     @group = ContainerGroup.where(:name => "monitoring-influx-grafana-controller-22icy").first
@@ -587,7 +581,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       end
 
       # TODO: pending graph tag mapping implementation
-      include_examples "kubernetes refresher VCR tests", :check_tag_mapping => false
+      include_examples "kubernetes refresher VCR tests"
     end
 
     context "with :batch saver" do
@@ -598,7 +592,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       end
 
       # TODO: pending graph tag mapping implementation
-      include_examples "kubernetes refresher VCR tests", :check_tag_mapping => false
+      include_examples "kubernetes refresher VCR tests"
     end
   end
 end


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/16453 for specs
- [x] https://github.com/ManageIQ/manageiq/pull/16499 for fixing that spec
- [x] https://github.com/ManageIQ/manageiq/pull/16501 to define `Tag.controlled_by_mapping` scope — merged
    (~~OR revive reverted https://github.com/ManageIQ/manageiq/pull/16449~~)

Overview/plan issue: #126

(added test for not removing user-assigned tag has been extracted to #170 and already merged)

@miq-bot add-label enhancement gaprindashvili/yes
https://bugzilla.redhat.com/show_bug.cgi?id=1470021

@Ladas @moolitayer please review