### PR TITLE
Fix Inventory Collector has_required_role?

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collector_worker.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collector_worker.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollectorWorke
   require_nested :Runner
 
   def self.has_required_role?
-    !worker_settings[:disabled] && Settings.fetch_path(:ems_refresh, ems_class.ems_type.to_sym, :inventory_object_refresh)
+    return false unless Settings.fetch_path(:ems_refresh, ems_class.ems_type.to_sym, :inventory_object_refresh)
+    super
   end
 end


### PR DESCRIPTION
The has_required_role? method wasn't calling the base
MiqWorker#has_required_role? leading to all workers in the zone running
the inventory collector.

Depends: ~~https://github.com/ManageIQ/manageiq/pull/16415~~