### PR TITLE
Set the target payload for watch inventory collector

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collector_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collector_mixin.rb
@@ -63,14 +63,13 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollectorMixi
 
     ems_ref = parse_notice_pod_ems_ref(object)
 
-    ManagerRefresh::Target.new(
+    target_opts = {
       :manager     => ems,
       :association => :container_groups,
-      :manager_ref => ems_ref,
-      :options     => {
-        :payload => object.to_json,
-      }
-    )
+      :manager_ref => ems_ref
+    }
+
+    ManagerRefresh::Target.new(target_opts).tap { |target| target.payload = object.to_json }
   end
 
   def stop_watch_thread

--- a/app/models/manageiq/providers/kubernetes/container_manager/target_collection_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/target_collection_mixin.rb
@@ -37,7 +37,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::TargetCollectionMixin
   end
 
   def pod_list
-    target.targets.map { |target| JSON.parse(target.options[:payload], :object_class => OpenStruct) }
+    target.targets.map { |target| JSON.parse(target.payload, :object_class => OpenStruct) }
   end
 
   private

--- a/app/models/manageiq/providers/kubernetes/container_manager/target_collection_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/target_collection_mixin.rb
@@ -37,7 +37,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::TargetCollectionMixin
   end
 
   def pod_list
-    target.targets.map { |target| JSON.parse(target.payload, :object_class => OpenStruct) }
+    target.targets.map do |target|
+      payload = target.payload
+      next if payload.nil?
+
+      JSON.parse(payload, :object_class => OpenStruct)
+    end.compact
   end
 
   private

--- a/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -62,7 +62,9 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
       :manager     => @ems,
       :association => :container_groups,
       :manager_ref => ems_ref,
-    ).tap { |t| t.payload = notice['object'].to_json }
+    )
+
+    target.payload = notice['object'].to_json
 
     EmsRefresh.queue_refresh(target)
   end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -62,10 +62,7 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
       :manager     => @ems,
       :association => :container_groups,
       :manager_ref => ems_ref,
-      :options     => {
-        :payload => notice['object'].to_json,
-      },
-    )
+    ).tap { |t| t.payload = notice['object'].to_json }
 
     EmsRefresh.queue_refresh(target)
   end


### PR DESCRIPTION
Set the target payload explicitly and clear it when the refresh is finished.  The post_refresh_ems_cleanup method is called at least from here https://github.com/ManageIQ/manageiq/blob/master/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb#L41-L43 so it will be called even if refresh throws an exception.

Related to: https://github.com/ManageIQ/manageiq/pull/16413
                  https://github.com/ManageIQ/manageiq-providers-openshift/pull/69