### PR TITLE
Use Proetheus timeouts form settings

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_client_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_client_mixin.rb
@@ -10,6 +10,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Promet
   end
 
   def prometheus_client_new(uri, credentials, options)
+    worker_class = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker
+
     Faraday.new(
       :url     => uri.to_s,
       :proxy   => options[:http_proxy_uri].empty? ? nil : options[:http_proxy_uri],
@@ -18,8 +20,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Promet
         :cert_store => options[:ssl_cert_store]
       },
       :request => {
-        :open_timeout => 2, # opening a connection
-        :timeout      => 5  # waiting for response
+        :open_timeout => worker_class.worker_settings[:prometheus_open_timeout] || 5,
+        :timeout      => worker_class.worker_settings[:prometheus_request_timeout] || 30
       },
       :headers => {
         :Authorization => "Bearer " + credentials[:token]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -78,5 +78,7 @@
           :ems_metrics_collector_worker_kubernetes:
             :metrics_port: 5000
             :metrics_path: "/hawkular/metrics"
+            :prometheus_open_timeout: 5
+            :prometheus_request_timeout: 30
         :ems_refresh_worker:
           :ems_refresh_worker_kubernetes: {}


### PR DESCRIPTION
Description

Metrics collection from OCP 3.7 using Prometheus may hit timeout while collecting metrics.

a. the default timeouts are too small
b. users can not set new timeout values to fit their system

This PR uses the settings needed to adjust the timeouts.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1511341