### PR TITLE
Enable getting multiple alert for an incident

### DIFF
--- a/app/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher/runner_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher/runner_mixin.rb
@@ -82,10 +82,9 @@ module ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher::RunnerM
     # TODO(mtayer): remove after https://github.com/ManageIQ/manageiq/pull/16339
     event[:ems_ref] = incident_identifier(labels, annotations, event["startsAt"])
     event[:resolved] = event["status"] == "resolved"
-    timestamp = event[:resolved] ? event["endsAt"] : event["startsAt"]
     {
       :source     => "DATAWAREHOUSE",
-      :timestamp  => timestamp,
+      :timestamp  => Time.zone.now,
       :event_type => "datawarehouse_alert",
       :message    => annotations["message"],
       :ems_ref    => incident_identifier(labels, annotations, event["startsAt"]),


### PR DESCRIPTION
Currently when an incident starts (e.g Container Node High Memory Usage) we get notified ONCE according to our selected notification method. We will be notified again when the incident is resolved.
For our use case (operators monitoring a cluster) one would want to keep getting alerts on an open issue until it is fixed. 

Prometheus keeps sending out messages when an incident is open but we created only one EmsEvent out of them since events with a similar time stamp mask each other and Prometheus startsAt is the same for alerts coming from the same incident.

ems_ref should still consider startsAt since that would still make sure we are only creating one MiqAlertStatus per incident.