### PR TITLE
Update hawkular gem version

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "hawkular-client", "~> 4.1"
+  s.add_runtime_dependency "hawkular-client", "~> 5.0.0.pre1"
   s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"
   s.add_runtime_dependency "kubeclient",      "~>2.4.0"
 


### PR DESCRIPTION
We have released a new version of the `hawkular-client` gem.
It changes the inventory and operations, I don't think this should affect your code in any way.

In a close future we are going to start using prometheus instead of hawkular metrics, so we will remove metrics from the `Hawkular::Client` [1]. 
It will still remain in the code, you will have to instantiate it explicitly (I think you already do that).

[1] https://github.com/hawkular/hawkular-client-ruby/blob/master/lib/hawkular/hawkular_client.rb#L10