### PR TITLE
read image acquiring status

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -145,6 +145,12 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
       _log.error("analyzing image-inspector metadata for #{options[:docker_image_id]} failed with error: #{e}")
     end
 
+    if inspector_metadata.ImageAcquireSuccess == false
+      msg = "image acquiring error: #{inspector_metadata.ImageAcquireError}"
+      _log.error(msg)
+      return queue_signal(:abort_job, msg, 'error')
+    end
+
     verify_error = verify_scanned_image_id(inspector_metadata)
     if verify_error
       _log.error(verify_error)

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -74,16 +74,20 @@ class MockImageInspectorClient
 end
 
 class MockFailedImageInspectorClient < MockImageInspectorClient
-  def initialize(status, msg, *args)
+  def initialize(oscap_status, oscap_msg, image_acq_success = true, image_acq_error = "", *args)
     super(*args)
-    @status = status
-    @msg = msg
+    @oscap_status = oscap_status
+    @oscap_msg = oscap_msg
+    @image_acq_success = image_acq_success
+    @image_acq_error = image_acq_error
   end
 
   def fetch_metadata(*_args)
     os = super
-    os["OpenSCAP"] = OpenStruct.new("Status"       => @status,
-                                    "ErrorMessage" => @msg)
+    os["OpenSCAP"] = OpenStruct.new("Status"       => @oscap_status,
+                                    "ErrorMessage" => @oscap_msg)
+    os["ImageAcquireSuccess"] = @image_acq_success
+    os["ImageAcquireError"] = @image_acq_error
     os
   end
 
@@ -382,7 +386,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
 
       it 'set the ok status from image-inspector OSCAP' do
         allow_any_instance_of(described_class).to receive_messages(
-          :image_inspector_client => MockFailedImageInspectorClient.new("Success", "", IMAGE_ID)
+          :image_inspector_client => MockFailedImageInspectorClient.new("Success", "", true, "", IMAGE_ID)
         )
         @job.signal(:start)
         expect(@job.state).to eq 'finished'
@@ -393,13 +397,26 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
 
       it 'set the warn status from image-inspector OSCAP' do
         allow_any_instance_of(described_class).to receive_messages(
-          :image_inspector_client => MockFailedImageInspectorClient.new("Error", OSCAP_ERROR_MSG, IMAGE_ID)
+          :image_inspector_client => MockFailedImageInspectorClient.new("Error", OSCAP_ERROR_MSG, true, "", IMAGE_ID)
         )
         @job.signal(:start)
         expect(@job.state).to eq 'finished'
         expect(@job.status).to eq 'warn'
         expect(@job.message).to eq OSCAP_ERROR_MSG
         expect(@image.last_scan_result.scan_result_message).to eq OSCAP_ERROR_MSG
+      end
+    end
+
+    context 'Image Acquiring Status' do
+      it 'Detects when image acquiring failed and reports the error' do
+        IMG_ACQ_ERR = "can't find image".freeze
+        allow_any_instance_of(described_class).to receive_messages(
+          :image_inspector_client => MockFailedImageInspectorClient.new("Sucess", "", false, IMG_ACQ_ERR, IMAGE_ID)
+        )
+        @job.signal(:start)
+        expect(@job.state).to eq 'finished'
+        expect(@job.status).to eq 'error'
+        expect(@job.message).to eq "image acquiring error: #{IMG_ACQ_ERR}"
       end
     end
 


### PR DESCRIPTION
Meant to report that image-inspector failed to acquire the image,  this will read ImageAcquireSuccess, ImageAcquireError and abort the job if needed with the error reported from image-inspector.

Based on image-inspector change from: https://github.com/openshift/image-inspector/pull/82

Currently (Before these two fixes) when Image-Inspector is failing to acquire the image it will exit and the Job on the ManageIQ side will wait until timeout is reached for the information to be served.

When the image-inspector image is updated with this change but ManageIQ is running without this patch the error message will look similar to this:
```
cannot analyze image 172.30.6.216:5000/test2/origin-ruby-sample@sha256:050b667cd1c1d5c5781f0c8ee5763ab5ef26e3a15c4d85cf7d143c1513890cec with id 172.30.6.216: detected ids were 
```

But this patch will change it to:
```
image acquiring error: Unable to pull docker image: <nil>
```

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1491643
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1484936