### PR TITLE
Make sure Container has always the right STI type

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -1032,6 +1032,7 @@ module ManageIQ::Providers::Kubernetes
 
     def parse_container_spec(container_spec, pod_id)
       new_result = {
+        :type                 => 'ManageIQ::Providers::Kubernetes::ContainerManager::Container',
         :ems_ref              => "#{pod_id}_#{container_spec.name}_#{container_spec.image}",
         :name                 => container_spec.name,
         :image                => container_spec.image,
@@ -1079,7 +1080,6 @@ module ManageIQ::Providers::Kubernetes
       return if container_image.nil?
 
       h = {
-        :type            => 'ManageIQ::Providers::Kubernetes::ContainerManager::Container',
         :restart_count   => container.restartCount,
         :backing_ref     => container.containerID,
         :container_image => container_image


### PR DESCRIPTION
Make sure Container has always the right STI type. Before, the
missing image could cause the STI type is Container, which
made metrics capture fail.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1517676