### PR TITLE
Drop :tags blacklist, refresh now extracts :tags to separate collection

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
@@ -247,7 +247,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
           :parent               => manager,
           :builder_params       => {:ems_id => manager.id},
           :association          => :container_routes,
-          :attributes_blacklist => [:namespace, :tags],
+          :attributes_blacklist => [:namespace],
         )
       )
     initialize_custom_attributes_collections(@collections[:container_routes], %w(labels))
@@ -283,7 +283,6 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
           :parent               => manager,
           :builder_params       => {:ems_id => manager.id},
           :association          => :container_builds,
-          :attributes_blacklist => [:tags],
           :secondary_refs       => {:by_namespace_and_name => [:namespace, :name]},
         )
       )


### PR DESCRIPTION
- [x] Depends on: to https://github.com/ManageIQ/manageiq-providers-openshift/pull/64

Blacklisting was a lazy way to discard unimplemented tags (analogous to `h.except!(:tags)` I removed in few other places), unnecessary after https://github.com/ManageIQ/manageiq-providers-openshift/pull/64.

https://bugzilla.redhat.com/show_bug.cgi?id=1470021
