### PR TITLE
Make container events belong to pod

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -93,8 +93,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
     when 'Pod'
       /^spec.containers{(?<container_name>.*)}$/ =~ event_data[:fieldpath]
       unless container_name.nil?
-        event_type_prefix = "CONTAINER"
         event_data[:container_name] = container_name
+        event_data[:reason] = "Container" + event_data[:reason] # Failed ~> ContainerFailed
       end
       event_data[:container_group_name] = event_data[:name]
       event_data[:container_namespace] = event_data[:namespace]

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -94,7 +94,6 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
       /^spec.containers{(?<container_name>.*)}$/ =~ event_data[:fieldpath]
       unless container_name.nil?
         event_data[:container_name] = container_name
-        event_data[:reason] = "Container" + event_data[:reason] # Failed ~> ContainerFailed
       end
       event_data[:container_group_name] = event_data[:name]
       event_data[:container_namespace] = event_data[:namespace]

--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -69,7 +69,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           :kind                 => 'Pod',
           :name                 => 'heapster-aas69',
           :namespace            => 'openshift-infra',
-          :reason               => 'Killing',
+          :reason               => 'ContainerKilling',
           :message              => 'Killing container with docker id 18a563fdb87c: failed to call event handler: '\
                                    'Error executing in Docker Container: -1',
           :uid                  => '72d3098a-4f6a-11e6-b177-525400c7c086',
@@ -77,7 +77,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           :container_name       => 'heapster',
           :container_group_name => 'heapster-aas69',
           :container_namespace  => 'openshift-infra',
-          :event_type           => 'CONTAINER_KILLING'
+          :event_type           => 'POD_CONTAINERKILLING'
         }
         event = array_recursive_ostruct(:object => kubernetes_event)
         expect(test_class.new.extract_event_data(event)).to eq(expected_data)

--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -63,13 +63,13 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
         }
       end
 
-      it 'extracts CONTAINER_KILLING data' do
+      it 'extracts POD_KILLING data' do
         expected_data = {
           :timestamp            => '2016-07-21T20:01:56Z',
           :kind                 => 'Pod',
           :name                 => 'heapster-aas69',
           :namespace            => 'openshift-infra',
-          :reason               => 'ContainerKilling',
+          :reason               => 'Killing',
           :message              => 'Killing container with docker id 18a563fdb87c: failed to call event handler: '\
                                    'Error executing in Docker Container: -1',
           :uid                  => '72d3098a-4f6a-11e6-b177-525400c7c086',
@@ -77,7 +77,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           :container_name       => 'heapster',
           :container_group_name => 'heapster-aas69',
           :container_namespace  => 'openshift-infra',
-          :event_type           => 'POD_CONTAINERKILLING'
+          :event_type           => 'POD_KILLING'
         }
         event = array_recursive_ostruct(:object => kubernetes_event)
         expect(test_class.new.extract_event_data(event)).to eq(expected_data)


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1496179

This makes `event_data[:event_type]` equal `POD_FAILED` 
instead of  `CONTAINER_FAILED` 
part of ManageIQ/manageiq#16583

@cben @moolitayer @enoodle Please review