### PR TITLE
Make capture interval a multiple of 30s

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -18,7 +18,7 @@ module ManageIQ::Providers
     require_nested :HawkularCaptureContext
     require_nested :PrometheusCaptureContext
 
-    INTERVAL = 20.seconds
+    INTERVAL = 60.seconds
 
     VIM_STYLE_COUNTERS = {
       "cpu_usage_rate_average"     => {
@@ -51,6 +51,9 @@ module ManageIQ::Providers
     }
 
     def capture_context(ems, target, start_time, end_time)
+      # make start_time align to minutes
+      start_time = start_time.beginning_of_minute
+
       # check for prometheus endpoint, ems must be set
       if ems.connection_configurations.prometheus.try(:endpoint)
         PrometheusCaptureContext.new(target, start_time, end_time, INTERVAL)

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_mixin.rb
@@ -60,10 +60,11 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
 
     def process_cpu_counters_rate(counters_rate)
       @metrics |= ['cpu_usage_rate_average'] unless counters_rate.empty?
-      total_cpu_time = @node_cores * CPU_NANOSECONDS * @interval
+      sec_cpu_time = @node_cores * CPU_NANOSECONDS
       counters_rate.each do |x|
+        interval = (x['end'] - x['start']) / 1.in_milliseconds
         timestamp = Time.at(x['start'] / 1.in_milliseconds).utc
-        avg_usage = (x['avg'] * 100.0) / total_cpu_time
+        avg_usage = (x['min'] * 100.0) / (sec_cpu_time * interval)
         @ts_values[timestamp]['cpu_usage_rate_average'] = avg_usage
       end
     end
@@ -72,7 +73,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
       @metrics |= ['mem_usage_absolute_average'] unless gauges_data.empty?
       gauges_data.each do |x|
         timestamp = Time.at(x['start'] / 1.in_milliseconds).utc
-        avg_usage = (x['avg'] / 1.megabytes) * 100.0 / @node_memory
+        avg_usage = (x['min'] / 1.megabytes) * 100.0 / @node_memory
         @ts_values[timestamp]['mem_usage_absolute_average'] = avg_usage
       end
     end
@@ -80,8 +81,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
     def process_net_counters_rate(counters_rate)
       @metrics |= ['net_usage_rate_average'] unless counters_rate.empty?
       counters_rate.each do |x|
+        interval = (x['end'] - x['start']) / 1.in_milliseconds
         timestamp = Time.at(x['start'] / 1.in_milliseconds).utc
-        avg_usage_kb = x['avg'] / (1.kilobyte.to_f * @interval)
+        avg_usage_kb = x['min'] / (1.kilobyte.to_f * interval)
         @ts_values[timestamp]['net_usage_rate_average'] = avg_usage_kb
       end
     end
@@ -98,7 +100,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
           {
             'start' => k,
             'end'   => [sum['end'], n['end']].max,
-            'avg'   => sum['avg'] + n['avg']
+            'min'   => sum['min'] + n['min']
           }
         end
       end
@@ -106,11 +108,20 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
 
     def compute_derivative(counters)
       counters.each_cons(2).map do |prv, n|
-        # Add min, median, max, percentile95th, etc. if needed
+        # Add min, median, min, percentile95th, etc. if needed
+        # time window:
+        # 00:00                                        01:00
+        # ^ (sample start time)                        ^ (next sample start time)
+        # ^ (sample min/max/avg value)                 ^ (next sample min/max/avg value)
+        #       ^ (real sample time)         ^ (real sample time)          ^ (real sample time)
+        #      ^ (real sample value)        ^ (real sample value)           ^ (real sample value)
+        # we use:
+        # (T = start of window timestamp, V = min value of window samples)
+        # because the min value is the value of the sample closest to start of window.
         {
-          'start' => n['start'],
-          'end'   => n['end'],
-          'avg'   => n['avg'] - prv['avg']
+          'start' => prv['start'],
+          'end'   => n['start'],
+          'min'   => n['min'] - prv['min']
         }
       end
     end

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context.rb
@@ -195,7 +195,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
       # insert the raw metrics into the @ts_values global object
       raw_metrics['gauge'][full_key].each do |metric|
         timestamp = Time.at(metric['start'] / 1.in_milliseconds).utc
-        @ts_values[timestamp][key] = metric['avg'] unless metric['empty']
+        @ts_values[timestamp][key] = metric['max'] unless metric['empty']
       end
     end
 

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
@@ -100,7 +100,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
 
         {
           "start" => start_sec.to_i.in_milliseconds,
-          "avg"   => x[1].to_f
+          "end"   => (start_sec.to_i + @interval.to_i).in_milliseconds,
+          "min"   => x[1].to_f
         }
       end
     end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_spec.rb
@@ -70,7 +70,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Prom
 
         data = context.collect_metrics
 
-        expect(data.count).to be < 18
+        expect(data.count).to be > 10
+        expect(data.count).to be < 13
       end
     end
   end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -47,69 +47,34 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
     # TODO: include also sort_and_normalize in the tests
     METRICS_EXERCISES = [
       {
-        :counters => [
+        :counters           => [
           {
             :args => 'cpu/usage',
             :data => [
-              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 0},
-              {'start' => 1446500020000, 'end' => 1446500040000, 'avg' => 4000000000}
+              {'start' => 1_446_500_000_000, 'end' => 1_446_500_060_000, 'min' => 0},
+              {'start' => 1_446_500_060_000, 'end' => 1_446_500_120_000, 'min' => 12_000_000_000},
             ]
           },
           {
             :args => 'network/tx',
             :data => [
-              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 0},
-              {'start' => 1446500020000, 'end' => 1446500040000, 'avg' => 153600}
+              {'start' => 1_446_500_000_000, 'end' => 1_446_500_060_000, 'min' => 0},
+              {'start' => 1_446_500_060_000, 'end' => 1_446_500_120_000, 'min' => 460_800}
             ]
           },
           {
             :args => 'network/rx',
             :data => [
-              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 0},
-              {'start' => 1446500020000, 'end' => 1446500040000, 'avg' => 51200}
+              {'start' => 1_446_500_000_000, 'end' => 1_446_500_060_000, 'min' => 0},
+              {'start' => 1_446_500_060_000, 'end' => 1_446_500_120_000, 'min' => 153_600}
             ]
           }
         ],
-        :gauges => [
+        :gauges             => [
           {
             :args => 'memory/usage',
             :data => [
-              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 1073741824}
-            ]
-          }
-        ],
-        :node_expected      => {},
-        :container_expected => {}
-      },
-      {
-        :counters => [
-          {
-            :args => 'cpu/usage',
-            :data => [
-              {'start' => 1446499980000, 'end' => 1446500000000, 'avg' => 0},
-              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 4000000000}
-            ]
-          },
-          {
-            :args => 'network/tx',
-            :data => [
-              {'start' => 1446499980000, 'end' => 1446500000000, 'avg' => 0},
-              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 153600}
-            ]
-          },
-          {
-            :args => 'network/rx',
-            :data => [
-              {'start' => 1446499980000, 'end' => 1446500000000, 'avg' => 0},
-              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 51200}
-            ]
-          }
-        ],
-        :gauges => [
-          {
-            :args => 'memory/usage',
-            :data => [
-              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 1073741824}
+              {'start' => 1_446_500_000_000, 'end' => 1_446_500_060_000, 'min' => 1_073_741_824}
             ]
           }
         ],
@@ -126,6 +91,41 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
             "mem_usage_absolute_average" => 50.0
           }
         }
+      },
+      {
+        :counters           => [
+          {
+            :args => 'cpu/usage',
+            :data => [
+              {'start' => 1_446_499_940_000, 'end' => 1_446_500_000_000, 'min' => 0},
+              {'start' => 1_446_500_000_000, 'end' => 1_446_500_060_000, 'min' => 12_000_000_000}
+            ]
+          },
+          {
+            :args => 'network/tx',
+            :data => [
+              {'start' => 1_446_499_940_000, 'end' => 1_446_500_000_000, 'min' => 0},
+              {'start' => 1_446_500_000_000, 'end' => 1_446_500_060_000, 'min' => 460_800}
+            ]
+          },
+          {
+            :args => 'network/rx',
+            :data => [
+              {'start' => 1_446_499_940_000, 'end' => 1_446_500_000_000, 'min' => 0},
+              {'start' => 1_446_500_000_000, 'end' => 1_446_500_060_000, 'min' => 153_600}
+            ]
+          }
+        ],
+        :gauges             => [
+          {
+            :args => 'memory/usage',
+            :data => [
+              {'start' => 1_446_500_000_000, 'end' => 1_446_500_060_000, 'min' => 1_073_741_824}
+            ]
+          }
+        ],
+        :node_expected      => {},
+        :container_expected => {}
       }
     ]
 


### PR DESCRIPTION
**Description**

TL;DR This PR change query rate from  Hawkular/Prometheus to 60s.

Metrics are scraped from k8s/openshift once every 30s into Hawkular/Prometheus.
Currently we query data from Hawkular/Prometheus every 20s, this create a response with missing data.

After discussion we decided to query from Hawkular/Prometheus every 60s, because it is a multiple of base rate (e.g. 30s) and allow for missing heartbeat once in a while.

Removed from #159 

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1524183