### PR TITLE
Parse and save quota scopes

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
@@ -40,6 +40,14 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
         :attributes_blacklist => [:namespace],
       )
     )
+    @collections[:container_quota_scopes] = ::ManagerRefresh::InventoryCollection.new(
+      shared_options.merge(
+        :model_class => ContainerQuotaScope,
+        :parent      => manager,
+        :association => :container_quota_scopes,
+        :manager_ref => [:container_quota, :scope],
+      )
+    )
     @collections[:container_quota_items] = ::ManagerRefresh::InventoryCollection.new(
       shared_options.merge(
         :model_class => ContainerQuotaItem,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -438,11 +438,15 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
             :creationTimestamp => '2015-08-17T09:16:46Z',
           },
           :spec     => {
-            :hard => {
+            :hard   => {
               :cpu    => '30',
               :pods   => '100',
               :memory => '10M'
-            }
+            },
+            :scopes => [
+              "Terminating",
+              "NotBestEffort"
+            ]
           },
           :status   => {
             :hard => {
@@ -457,12 +461,20 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
             }
           }
         )
-      )).to eq(:name                  => 'test-quota',
-               :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-               :ems_created_on        => '2015-08-17T09:16:46Z',
-               :resource_version      => '165339',
-               :namespace             => 'test-namespace',
-               :container_quota_items => [
+      )).to eq(:name                   => 'test-quota',
+               :ems_ref                => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+               :ems_created_on         => '2015-08-17T09:16:46Z',
+               :resource_version       => '165339',
+               :namespace              => 'test-namespace',
+               :container_quota_scopes => [
+                 {
+                   :scope => "Terminating"
+                 },
+                 {
+                   :scope => "NotBestEffort"
+                 }
+               ],
+               :container_quota_items  => [
                  {
                    :resource       => "cpu",
                    :quota_desired  => 30,
@@ -497,12 +509,13 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                            },
                            :spec     => {},
                            :status   => {})))
-        .to eq(:name                  => 'test-quota',
-               :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-               :ems_created_on        => '2015-08-17T09:16:46Z',
-               :resource_version      => '165339',
-               :namespace             => 'test-namespace',
-               :container_quota_items => [])
+        .to eq(:name                   => 'test-quota',
+               :ems_ref                => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+               :ems_created_on         => '2015-08-17T09:16:46Z',
+               :resource_version       => '165339',
+               :namespace              => 'test-namespace',
+               :container_quota_scopes => [],
+               :container_quota_items  => [])
     end
 
     it "handles quotas with no status" do
@@ -519,12 +532,13 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                                :cpu => '30'
                              }},
                            :status   => {})))
-        .to eq(:name                  => 'test-quota',
-               :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-               :ems_created_on        => '2015-08-17T09:16:46Z',
-               :resource_version      => '165339',
-               :namespace             => 'test-namespace',
-               :container_quota_items => [
+        .to eq(:name                   => 'test-quota',
+               :ems_ref                => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+               :ems_created_on         => '2015-08-17T09:16:46Z',
+               :resource_version       => '165339',
+               :namespace              => 'test-namespace',
+               :container_quota_scopes => [],
+               :container_quota_items  => [
                  {
                    :resource       => "cpu",
                    :quota_desired  => 30,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -324,7 +324,8 @@ shared_examples "kubernetes refresher VCR tests" do
 
   def assert_specific_container_quota
     container_quota = ContainerQuota.find_by(:name => "quota")
-    container_quota.ems_created_on.kind_of?(ActiveSupport::TimeWithZone)
+    expect(container_quota.ems_created_on).to be_a(ActiveSupport::TimeWithZone)
+    expect(container_quota.container_quota_scopes.count).to eq(0)
     expect(container_quota.container_quota_items.count).to eq(8)
     cpu_quota = container_quota.container_quota_items.select { |x| x[:resource] == 'cpu' }[0]
     expect(cpu_quota).to have_attributes(


### PR DESCRIPTION
Kubernetes namespaces (aka openshift projects) may have quotas.
Each quota may have one or more *scopes*, which we didn't store before but should:
https://kubernetes.io/docs/concepts/policy/resource-quotas/#quota-scopes
https://docs.openshift.com/container-platform/3.7/admin_guide/quota.html#quota-scopes

- [x] Schema was added in https://github.com/ManageIQ/manageiq-schema/pull/111
- [ ] Depends on https://github.com/ManageIQ/manageiq/pull/16655 for new model, model associations, and old refresh.

https://bugzilla.redhat.com/show_bug.cgi?id=1504560

@zeari @enoodle please review.  VCR tests coming in later PR.