### PR TITLE
Use prometheus client instead of faraday

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("image-inspector-client",          "~>1.0.3")
   s.add_runtime_dependency("kubeclient",                      "~>2.4.0")
   s.add_runtime_dependency("prometheus-alert-buffer-client",  "~> 0.2.0")
+  s.add_runtime_dependency("prometheus-api-client",           "~> 0.6")
 
   s.add_development_dependency("codeclimate-test-reporter", "~> 1.0.0")
   s.add_development_dependency("recursive-open-struct",     "~> 1.0.0")

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_client_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_client_spec.rb
@@ -33,7 +33,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Prom
     VCR.use_cassette("#{described_class.name.underscore}_fail_connect") do # , :record => :new_episodes) do
       @ems.connection_configurations.prometheus.authentication.auth_key = 'wrong_key'
       client = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::PrometheusClient.new(@ems)
-      expect { client.prometheus_try_connect }.to raise_error(MiqException::MiqInvalidCredentialsError)
+      expect { client.prometheus_try_connect }.to raise_error(Prometheus::ApiClient::Client::RequestError)
     end
   end
 end


### PR DESCRIPTION
**Description**

We want to leverage the new Prometheus API gem, for metrics collection.

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1468251 - Use Prometheus Metrics Ruby client

Note: this is the second part of https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/132