### PR TITLE
Support KubeVirt provider

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -79,6 +79,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     monitoring_manager.verify_credentials
   end
 
+  def verify_kubevirt_credentials
+    ensure_infra_manager
+    infra_manager.verify_credentials
+    infra_manager.verify_virt_supported
+  end
+
   # UI methods for determining availability of fields
   def supports_port?
     true
@@ -134,6 +140,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     at << :hawkular if has_authentication_type?(:hawkular)
     at << :prometheus if has_authentication_type?(:prometheus)
     at << :prometheus_alerts if has_authentication_type?(:prometheus_alerts)
+    at << :kubevirt if has_authentication_type?(:kubevirt)
     at
   end
 
@@ -153,6 +160,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
       verify_prometheus_credentials
     elsif options[:auth_type].to_s == "prometheus_alerts"
       verify_prometheus_alerts_credentials
+    elsif options[:auth_type].to_s == "kubevirt"
+      verify_kubevirt_credentials
     else
       with_provider_connection(options, &:api_valid?)
     end
@@ -171,7 +180,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   end
 
   def supported_auth_types
-    %w(default password bearer hawkular prometheus prometheus_alerts)
+    %w(default password bearer hawkular prometheus prometheus_alerts kubevirt)
   end
 
   def supports_authentication?(authtype)

--- a/app/models/manageiq/providers/kubernetes/virtualization_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/virtualization_manager_mixin.rb
@@ -1,0 +1,32 @@
+module ManageIQ::Providers::Kubernetes::VirtualizationManagerMixin
+  extend ActiveSupport::Concern
+
+  ENDPOINT_ROLE = :kubevirt
+
+  included do
+    delegate :authentication_check,
+             :authentication_for_summary,
+             :authentication_status,
+             :authentication_status_ok,
+             :authentication_token,
+             :authentications,
+             :endpoints,
+             :zone,
+             :to        => :parent_manager,
+             :allow_nil => true
+  end
+
+  module ClassMethods
+    def raw_connect(options)
+      ManageIQ::Providers::Kubevirt::InfraManager.raw_connect(options)
+    end
+  end
+
+  def virtualization_endpoint
+    connection_configurations.kubevirt.try(:endpoint)
+  end
+
+  def default_authentication_type
+    ENDPOINT_ROLE
+  end
+end


### PR DESCRIPTION
The kubevirt provider will be managed as a virtualization manager under
the container managers.

The endpoint and authentication of kubevirt will be selected by
:kubevirt role and authkey.

This PR depends on https://github.com/ManageIQ/manageiq/pull/16721.

Additional related PRs:

UI PR:
https://github.com/ManageIQ/manageiq-ui-classic/pull/3143

kubevirt provider PR:
https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/6/
