### PR TITLE
Don't try to parse empty data set returned from hawkualr

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context.rb
@@ -132,6 +132,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
     # @param key [String] the metrics key/group_id (e.g. cpu/usage).
     # @return [String] the metrics full key name (e.g. machine/example.com/cpu/usage).
     def get_metrics_key(raw_metrics, type, key)
+      raise CollectionFailure, "no #{type} metrics found for [#{@target.name}]" unless raw_metrics[type]
+
       # each object has only one metrics with some key/group_id ( e.g. each node has only one cpu/usage )
       raw_metrics[type].keys.find { |e| e.ends_with?(key) }
     end


### PR DESCRIPTION
If no metrics where pushed into Hawkular ( a problem with provider setup (*) ), it will return a valid answer (HTTP 200) with no data.

(*) On a system that was configured correctly we will get data with `empty=true` fields. 

On such systems we currently get:
NoMethodError: undefined method `keys' for nil:NilClass

This PR check that we have data in the response before trying to parse it.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1530627
  