### PR TITLE
Cast quota values to float in parser, to match float columns

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -934,15 +934,15 @@ module ManageIQ::Providers::Kubernetes
       end
 
       resource_quota.spec.hard.to_h.each do |resource_name, quota|
-        new_result_h[resource_name][:quota_desired] = parse_quantity(quota)
+        new_result_h[resource_name][:quota_desired] = parse_quantity(quota).to_f
       end
 
       resource_quota.status.hard.to_h.each do |resource_name, quota|
-        new_result_h[resource_name][:quota_enforced] = parse_quantity(quota)
+        new_result_h[resource_name][:quota_enforced] = parse_quantity(quota).to_f
       end
 
       resource_quota.status.used.to_h.each do |resource_name, quota|
-        new_result_h[resource_name][:quota_observed] = parse_quantity(quota)
+        new_result_h[resource_name][:quota_observed] = parse_quantity(quota).to_f
       end
 
       new_result_h.values


### PR DESCRIPTION
This works around bug in classic refresh where casting didn't happen,
so we can proceed with container quota archiving independently of
https://github.com/ManageIQ/manageiq/pull/16723
This way backporting of that fix can be decided independently.

https://bugzilla.redhat.com/show_bug.cgi?id=1504560

@miq-bot add-label enhancement, gaprindashvili/yes

@yaacov @zeari @moolitayer Please review.
Didn't add tests, because not sure if I should test anything here,
but will have tests for no unnecessary archiving in the archiving PR.