### PR TITLE
Add a queue metrics capture method to container manager

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -266,4 +266,17 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     # and these should automatically be translated to alerts.
     true
   end
+
+  def queue_metrics_capture
+    targets = Metric::Targets.capture_container_targets([self], {})
+
+    targets.each do |target|
+      begin
+        target.perf_capture_queue('realtime', :priority => MiqQueue::HIGH_PRIORITY)
+      rescue StandardError => err
+        _log.error("Failed to queue perf_capture for target [#{target.class.name}], [#{target.id}], [#{target.name}]: #{err}")
+        raise
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Description**
Add a method to queue reading of metrics.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1527877
Target: 5.9.1