### PR TITLE
[WIP] Log INFO instead of ERROR for no metrics

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -2,6 +2,12 @@ module ManageIQ::Providers
   class Kubernetes::ContainerManager::MetricsCapture < BaseManager::MetricsCapture
     class CollectionFailure < RuntimeError; end
 
+    class NoDataWarning < RuntimeError
+      def log_severity
+        :warn
+      end
+    end
+
     class TargetValidationError < RuntimeError
       def log_severity
         :error

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
@@ -99,7 +99,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
 
     def sort_and_normalize(response, metric_title, conversion_factor)
       unless response["result"] && response["result"][0]
-        raise CollectionFailure, "[#{@target} #{@target.name}] No data in response"
+        raise NoDataWarning, "[#{@target} #{@target.name}] No data in response"
       end
 
       response["result"][0]["values"].map do |x|

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -266,4 +266,17 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     # and these should automatically be translated to alerts.
     true
   end
+
+  def queue_metrics_capture
+    targets = Metric::Targets.capture_container_targets([self], {})
+
+    targets.each do |target|
+      begin
+        target.perf_capture_queue('realtime', :priority => MiqQueue::HIGH_PRIORITY)
+      rescue StandardError => err
+        _log.error("Failed to queue perf_capture for target [#{target.class.name}], [#{target.id}], [#{target.name}]: #{err}")
+        raise
+      end
+    end
+  end
 end


### PR DESCRIPTION
See following errors in the log[1] these are objects that are in an error state:
```
logging                logging-es-ops-data-master-t3rct3i0-1-deploy   0/1       Error              0          1d
openshift-management   manageiq-0                                     0/1       CrashLoopBackOff   509        1d
```

We should not error but at most warn because nothing unexpected happened.
(errors = bugs opened)

[1]
```
[----] E, [2018-01-09T17:34:18.809959 #21612:6d2f7c] ERROR -- : MIQ(ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture#perf_collect_metrics) Hawkular metrics service unavailable: ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure: [#<ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup:0x0000000f48fcd8> logging-es-ops-data-master-t3rct3i0-1-deploy] No data in response
[----] I, [2018-01-09T17:34:18.820689 #21612:6d2f7c]  INFO -- : Exception in realtime_block :total_time - Timings: {:capture_state=>0.0018694400787353516, :collect_data=>0.10036706924438477, :total_time=>0.11323738098144531}
[----] E, [2018-01-09T17:34:18.820882 #21612:6d2f7c] ERROR -- : MIQ(MiqQueue#deliver) Message id: [82711], Error: [ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure: [#<ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup:0x0000000f48fcd8> logging-es-ops-data-master-t3rct3i0-1-deploy] No data in response]
[----] E, [2018-01-09T17:34:18.820999 #21612:6d2f7c] ERROR -- : [ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure]: ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure: [#<ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup:0x0000000f48fcd8> logging-es-ops-data-master-t3rct3i0-1-deploy] No data in response  Method:[block in method_missing]
[----] E, [2018-01-09T17:34:18.821063 #21612:6d2f7c] ERROR -- : /home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:97:in `rescue in fetch_counters_data'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:83:in `fetch_counters_data'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:64:in `collect_metrics_for_labels'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:55:in `collect_group_metrics'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_mixin.rb:29:in `collect_metrics'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb:97:in `block in perf_collect_metrics'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:28:in `realtime_block'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb:95:in `perf_collect_metrics'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:6:in `perf_collect_metrics'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:193:in `block in just_perf_capture'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:35:in `realtime_block'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:189:in `just_perf_capture'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:135:in `perf_capture'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:117:in `perf_capture_realtime'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:449:in `block in dispatch_method'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:93:in `block in timeout'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `block in catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:108:in `timeout'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:448:in `dispatch_method'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:425:in `block in deliver'
/home/mtayer/dev/manageiq/app/models/user.rb:253:in `with_user_group'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:425:in `deliver'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:104:in `deliver_queue_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:134:in `deliver_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:152:in `block in do_work'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:146:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:146:in `do_work'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:329:in `block in do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:326:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:326:in `do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:153:in `run'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:127:in `start'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:22:in `start_worker'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:357:in `block in start_runner_via_fork'
/home/mtayer/.rvm/gems/ruby-2.4.1/gems/nakayoshi_fork-0.0.3/lib/nakayoshi_fork.rb:24:in `fork'
/home/mtayer/.rvm/gems/ruby-2.4.1/gems/nakayoshi_fork-0.0.3/lib/nakayoshi_fork.rb:24:in `fork'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:355:in `start_runner_via_fork'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:349:in `start_runner'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:396:in `start'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:266:in `start_worker'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `block in sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `times'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:53:in `block in sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:50:in `each'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:50:in `sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server.rb:141:in `start'
/home/mtayer/dev/manageiq/app/models/miq_server.rb:233:in `start'
/home/mtayer/dev/manageiq/lib/workers/evm_server.rb:27:in `start'
/home/mtayer/dev/manageiq/lib/workers/evm_server.rb:48:in `start'
/home/mtayer/dev/manageiq/lib/workers/bin/evm_server.rb:4:in `<main>'
[----] I, [2018-01-09T17:34:18.821136 #21612:6d2f7c]  INFO -- : MIQ(MiqQueue#delivered) Message id: [82711], State: [error], Delivered in [0.115685294] seconds
--
[----] E, [2018-01-09T17:34:23.978091 #21621:6d2f7c] ERROR -- : MIQ(ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture#perf_collect_metrics) Hawkular metrics service unavailable: Prometheus::ApiClient::Client::RequestError: Bad response from server
[----] I, [2018-01-09T17:34:23.998916 #21621:6d2f7c]  INFO -- : Exception in realtime_block :total_time - Timings: {:capture_state=>0.001500844955444336, :collect_data=>5.308959722518921, :total_time=>5.316612720489502}
[----] E, [2018-01-09T17:34:23.999223 #21621:6d2f7c] ERROR -- : MIQ(MiqQueue#deliver) Message id: [82710], Error: [Prometheus::ApiClient::Client::RequestError: Bad response from server]
[----] E, [2018-01-09T17:34:23.999505 #21621:6d2f7c] ERROR -- : [ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure]: Prometheus::ApiClient::Client::RequestError: Bad response from server  Method:[block in method_missing]
[----] E, [2018-01-09T17:34:23.999646 #21621:6d2f7c] ERROR -- : /home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:97:in `rescue in fetch_counters_data'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:83:in `fetch_counters_data'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:76:in `collect_metrics_for_labels'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:28:in `collect_node_metrics'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_mixin.rb:27:in `collect_metrics'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb:97:in `block in perf_collect_metrics'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:28:in `realtime_block'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb:95:in `perf_collect_metrics'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:6:in `perf_collect_metrics'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:193:in `block in just_perf_capture'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:35:in `realtime_block'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:189:in `just_perf_capture'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:135:in `perf_capture'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:117:in `perf_capture_realtime'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:449:in `block in dispatch_method'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:93:in `block in timeout'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `block in catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:108:in `timeout'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:448:in `dispatch_method'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:425:in `block in deliver'
/home/mtayer/dev/manageiq/app/models/user.rb:253:in `with_user_group'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:425:in `deliver'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:104:in `deliver_queue_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:134:in `deliver_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:152:in `block in do_work'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:146:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:146:in `do_work'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:329:in `block in do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:326:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:326:in `do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:153:in `run'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:127:in `start'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:22:in `start_worker'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:357:in `block in start_runner_via_fork'
/home/mtayer/.rvm/gems/ruby-2.4.1/gems/nakayoshi_fork-0.0.3/lib/nakayoshi_fork.rb:24:in `fork'
/home/mtayer/.rvm/gems/ruby-2.4.1/gems/nakayoshi_fork-0.0.3/lib/nakayoshi_fork.rb:24:in `fork'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:355:in `start_runner_via_fork'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:349:in `start_runner'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:396:in `start'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:266:in `start_worker'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `block in sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `times'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:53:in `block in sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:50:in `each'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:50:in `sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server.rb:141:in `start'
/home/mtayer/dev/manageiq/app/models/miq_server.rb:233:in `start'
/home/mtayer/dev/manageiq/lib/workers/evm_server.rb:27:in `start'
/home/mtayer/dev/manageiq/lib/workers/evm_server.rb:48:in `start'
/home/mtayer/dev/manageiq/lib/workers/bin/evm_server.rb:4:in `<main>'
[----] I, [2018-01-09T17:34:23.999871 #21621:6d2f7c]  INFO -- : MIQ(MiqQueue#delivered) Message id: [82710], State: [error], Delivered in [5.319230379] seconds
--
[----] E, [2018-01-09T17:34:24.417138 #21612:6d2f7c] ERROR -- : MIQ(ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture#perf_collect_metrics) Hawkular metrics service unavailable: ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure: [#<ManageIQ::Providers::Kubernetes::ContainerManager::Container:0x00000006cc1888> manageiq] No data in response
[----] I, [2018-01-09T17:34:24.428147 #21612:6d2f7c]  INFO -- : Exception in realtime_block :total_time - Timings: {:capture_state=>0.0018970966339111328, :collect_data=>0.08988404273986816, :total_time=>0.1030130386352539}
[----] E, [2018-01-09T17:34:24.428363 #21612:6d2f7c] ERROR -- : MIQ(MiqQueue#deliver) Message id: [82738], Error: [ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure: [#<ManageIQ::Providers::Kubernetes::ContainerManager::Container:0x00000006cc1888> manageiq] No data in response]
[----] E, [2018-01-09T17:34:24.428476 #21612:6d2f7c] ERROR -- : [ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure]: ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure: [#<ManageIQ::Providers::Kubernetes::ContainerManager::Container:0x00000006cc1888> manageiq] No data in response  Method:[block in method_missing]
[----] E, [2018-01-09T17:34:24.428545 #21612:6d2f7c] ERROR -- : /home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:97:in `rescue in fetch_counters_data'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:83:in `fetch_counters_data'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:64:in `collect_metrics_for_labels'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:40:in `collect_container_metrics'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_mixin.rb:28:in `collect_metrics'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb:97:in `block in perf_collect_metrics'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:28:in `realtime_block'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb:95:in `perf_collect_metrics'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:6:in `perf_collect_metrics'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:193:in `block in just_perf_capture'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:35:in `realtime_block'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:189:in `just_perf_capture'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:135:in `perf_capture'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:117:in `perf_capture_realtime'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:449:in `block in dispatch_method'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:93:in `block in timeout'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `block in catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:108:in `timeout'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:448:in `dispatch_method'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:425:in `block in deliver'
/home/mtayer/dev/manageiq/app/models/user.rb:253:in `with_user_group'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:425:in `deliver'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:104:in `deliver_queue_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:134:in `deliver_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:152:in `block in do_work'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:146:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:146:in `do_work'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:329:in `block in do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:326:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:326:in `do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:153:in `run'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:127:in `start'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:22:in `start_worker'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:357:in `block in start_runner_via_fork'
/home/mtayer/.rvm/gems/ruby-2.4.1/gems/nakayoshi_fork-0.0.3/lib/nakayoshi_fork.rb:24:in `fork'
/home/mtayer/.rvm/gems/ruby-2.4.1/gems/nakayoshi_fork-0.0.3/lib/nakayoshi_fork.rb:24:in `fork'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:355:in `start_runner_via_fork'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:349:in `start_runner'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:396:in `start'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:266:in `start_worker'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `block in sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `times'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:53:in `block in sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:50:in `each'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:50:in `sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server.rb:141:in `start'
/home/mtayer/dev/manageiq/app/models/miq_server.rb:233:in `start'
/home/mtayer/dev/manageiq/lib/workers/evm_server.rb:27:in `start'
/home/mtayer/dev/manageiq/lib/workers/evm_server.rb:48:in `start'
/home/mtayer/dev/manageiq/lib/workers/bin/evm_server.rb:4:in `<main>'
[----] I, [2018-01-09T17:34:24.428621 #21612:6d2f7c]  INFO -- : MIQ(MiqQueue#delivered) Message id: [82738], State: [error], Delivered in [0.105591615] seconds
--
[----] E, [2018-01-09T17:34:24.978596 #21621:6d2f7c] ERROR -- : MIQ(ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture#perf_collect_metrics) Hawkular metrics service unavailable: ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure: [#<ManageIQ::Providers::Kubernetes::ContainerManager::Container:0x0000000c84efe8> deployment] No data in response
[----] I, [2018-01-09T17:34:24.989866 #21621:6d2f7c]  INFO -- : Exception in realtime_block :total_time - Timings: {:capture_state=>0.0013837814331054688, :collect_data=>0.05037546157836914, :total_time=>0.060245513916015625}
[----] E, [2018-01-09T17:34:24.990035 #21621:6d2f7c] ERROR -- : MIQ(MiqQueue#deliver) Message id: [82746], Error: [ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure: [#<ManageIQ::Providers::Kubernetes::ContainerManager::Container:0x0000000c84efe8> deployment] No data in response]
[----] E, [2018-01-09T17:34:24.990161 #21621:6d2f7c] ERROR -- : [ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure]: ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CollectionFailure: [#<ManageIQ::Providers::Kubernetes::ContainerManager::Container:0x0000000c84efe8> deployment] No data in response  Method:[block in method_missing]
[----] E, [2018-01-09T17:34:24.990218 #21621:6d2f7c] ERROR -- : /home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:97:in `rescue in fetch_counters_data'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:83:in `fetch_counters_data'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:64:in `collect_metrics_for_labels'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb:40:in `collect_container_metrics'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_mixin.rb:28:in `collect_metrics'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb:97:in `block in perf_collect_metrics'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:28:in `realtime_block'
/home/mtayer/dev/manageiq/plugins/manageiq-providers-kubernetes/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb:95:in `perf_collect_metrics'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:6:in `perf_collect_metrics'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:193:in `block in just_perf_capture'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/home/mtayer/.rvm/gems/ruby-2.4.1/bundler/gems/manageiq-gems-pending-f793b3c6929e/lib/gems/pending/util/extensions/miq-benchmark.rb:35:in `realtime_block'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:189:in `just_perf_capture'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:135:in `perf_capture'
/home/mtayer/dev/manageiq/app/models/metric/ci_mixin/capture.rb:117:in `perf_capture_realtime'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:449:in `block in dispatch_method'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:93:in `block in timeout'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `block in catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:33:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/timeout.rb:108:in `timeout'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:448:in `dispatch_method'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:425:in `block in deliver'
/home/mtayer/dev/manageiq/app/models/user.rb:253:in `with_user_group'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:425:in `deliver'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:104:in `deliver_queue_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:134:in `deliver_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:152:in `block in do_work'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:146:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:146:in `do_work'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:329:in `block in do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:326:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:326:in `do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:153:in `run'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:127:in `start'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:22:in `start_worker'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:357:in `block in start_runner_via_fork'
/home/mtayer/.rvm/gems/ruby-2.4.1/gems/nakayoshi_fork-0.0.3/lib/nakayoshi_fork.rb:24:in `fork'
/home/mtayer/.rvm/gems/ruby-2.4.1/gems/nakayoshi_fork-0.0.3/lib/nakayoshi_fork.rb:24:in `fork'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:355:in `start_runner_via_fork'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:349:in `start_runner'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:396:in `start'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:266:in `start_worker'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `block in sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `times'
/home/mtayer/dev/manageiq/app/models/miq_worker.rb:153:in `sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:53:in `block in sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:50:in `each'
/home/mtayer/dev/manageiq/app/models/miq_server/worker_management/monitor.rb:50:in `sync_workers'
/home/mtayer/dev/manageiq/app/models/miq_server.rb:141:in `start'
/home/mtayer/dev/manageiq/app/models/miq_server.rb:233:in `start'
/home/mtayer/dev/manageiq/lib/workers/evm_server.rb:27:in `start'
/home/mtayer/dev/manageiq/lib/workers/evm_server.rb:48:in `start'
/home/mtayer/dev/manageiq/lib/workers/bin/evm_server.rb:4:in `<main>'
[----] I, [2018-01-09T17:34:24.990296 #21621:6d2f7c]  INFO -- : MIQ(MiqQueue#delivered) Message id: [82746], State: [error], Delivered in [0.062228456] seconds
```
  