### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -56,4 +56,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
   def self.event_monitor_class
     ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher
   end
+
+  def self.display_name(number = 1)
+    n_('Container Provider (Kubernetes)', 'Container Providers (Kubernetes)', number)
+  end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/container_group.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_group.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup < ::ContainerGroup
   alias_attribute :pod_uid, :ems_ref
+
+  def self.display_name(number = 1)
+    n_('Pod (Kubernetes)', 'Pods (Kubernetes)', number)
+  end
 end


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836