### PR TITLE
Skip hostname validation for monitoring manager

### DIFF
--- a/app/models/manageiq/providers/kubernetes/monitoring_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/monitoring_manager_mixin.rb
@@ -15,6 +15,10 @@ module ManageIQ::Providers::Kubernetes::MonitoringManagerMixin
              :zone,
              :to        => :parent_manager,
              :allow_nil => true
+
+    def self.hostname_required?
+      false
+    end
   end
 
   module ClassMethods


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1535941

The problem is that the monitoring manager looks for a default endpoint which it does not have. 
The parent provider has that endpoint and validates it anyway so no need for the monitoring manager to validate it.


Another solution could be to delegate the default endpoint from the monitoring_manager to the parent provider or just regard the alert endpoint as the default endpoint for monitoring.
Monitoring manager has some prep work for the latter: https://github.com/manageiq/manageiq-providers-kubernetes/blob/master/app/models/manageiq/providers/kubernetes/monitoring_manager_mixin.rb#L59

but ext_management_system doesnt take it into account:
https://github.com/manageiq/manageiq/blob/master/app/models/ext_management_system.rb#L295


@cben @moolitayer Please review

@miq-bot add_label bug, gapridashvili/yes
