### PR TITLE
only use the ImageAcquireError field

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -145,7 +145,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
       _log.error("analyzing image-inspector metadata for #{options[:docker_image_id]} failed with error: #{e}")
     end
 
-    if inspector_metadata.ImageAcquireSuccess == false
+    if inspector_metadata.ImageAcquireError.present?
       msg = "image acquiring error: #{inspector_metadata.ImageAcquireError}"
       _log.error(msg)
       return queue_signal(:abort_job, msg, 'error')

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -102,11 +102,10 @@ class MockImageInspectorClient
 end
 
 class MockFailedImageInspectorClient < MockImageInspectorClient
-  def initialize(oscap_status, oscap_msg, image_acq_success = true, image_acq_error = "", *args)
+  def initialize(oscap_status, oscap_msg, image_acq_error = "", *args)
     super(*args)
     @oscap_status = oscap_status
     @oscap_msg = oscap_msg
-    @image_acq_success = image_acq_success
     @image_acq_error = image_acq_error
   end
 
@@ -114,7 +113,6 @@ class MockFailedImageInspectorClient < MockImageInspectorClient
     os = super
     os["OpenSCAP"] = OpenStruct.new("Status"       => @oscap_status,
                                     "ErrorMessage" => @oscap_msg)
-    os["ImageAcquireSuccess"] = @image_acq_success
     os["ImageAcquireError"] = @image_acq_error
     os
   end
@@ -459,7 +457,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
 
       it 'set the ok status from image-inspector OSCAP' do
         allow_any_instance_of(described_class).to receive_messages(
-          :image_inspector_client => MockFailedImageInspectorClient.new("Success", "", true, "", IMAGE_ID)
+          :image_inspector_client => MockFailedImageInspectorClient.new("Success", "", "", IMAGE_ID)
         )
         @job.signal(:start)
         expect(@job.state).to eq 'finished'
@@ -470,7 +468,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
 
       it 'set the warn status from image-inspector OSCAP' do
         allow_any_instance_of(described_class).to receive_messages(
-          :image_inspector_client => MockFailedImageInspectorClient.new("Error", OSCAP_ERROR_MSG, true, "", IMAGE_ID)
+          :image_inspector_client => MockFailedImageInspectorClient.new("Error", OSCAP_ERROR_MSG, "", IMAGE_ID)
         )
         @job.signal(:start)
         expect(@job.state).to eq 'finished'
@@ -484,7 +482,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
       it 'Detects when image acquiring failed and reports the error' do
         IMG_ACQ_ERR = "can't find image".freeze
         allow_any_instance_of(described_class).to receive_messages(
-          :image_inspector_client => MockFailedImageInspectorClient.new("Sucess", "", false, IMG_ACQ_ERR, IMAGE_ID)
+          :image_inspector_client => MockFailedImageInspectorClient.new("Sucess", "", IMG_ACQ_ERR, IMAGE_ID)
         )
         @job.signal(:start)
         expect(@job.state).to eq 'finished'


### PR DESCRIPTION
Due to changes in [1], the field `ImageAcquireSuccess` is not being used anymore


[1] https://github.com/openshift/image-inspector/pull/82