### PR TITLE
Add support for alert labels

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -18,6 +18,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
 
   include ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   include ManageIQ::Providers::Kubernetes::ContainerManager::Options
+  include ManageIQ::Providers::Kubernetes::ContainerManager::AlertLabels
 
   # See HasMonitoringManagerMixin
   has_one :monitoring_manager,

--- a/app/models/manageiq/providers/kubernetes/container_manager/alert_labels.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/alert_labels.rb
@@ -1,0 +1,41 @@
+#
+# This mixin implements the `alert_labels` feature.
+#
+module ManageIQ::Providers::Kubernetes::ContainerManager::AlertLabels
+  extend ActiveSupport::Concern
+
+  #
+  # Any provider that includes this mix-in will support the alert lables, populated from the labels
+  # provided by Prometheus.
+  #
+  included do
+    supports :alert_labels
+  end
+
+  #
+  # Returns the alert labels associated to the given alert status.
+  #
+  # @param alert_status [MiqAlertStatus] The alert status object.
+  # @return [Array<MiqAlertStatusLabel>] The array of labels.
+  #
+  def alert_labels(alert_status)
+    # Find the event that correspond to the given alert status:
+    event = EventStream.find_by(
+      :ems_id  => alert_status.ems_id,
+      :ems_ref => alert_status.event_ems_ref
+    )
+    return [] unless event
+
+    # Extract the hash of labels from the event full data:
+    labels = event.full_data && event.full_data['labels']
+    return [] unless labels
+
+    # Convert the hash to an array of label objects:
+    labels.map do |name, value|
+      label = MiqAlertStatusLabel.new
+      label.name = name
+      label.value = value
+      label
+    end
+  end
+end


### PR DESCRIPTION
This patch modifies the Kubernetes provider so that it supports alert
labels. These labels will be extracted from the `full_data` stored in
the event that generated the alert.

Fixes https://bugzilla.redhat.com/1520125

Note that this pull request depends on ManageIQ/manageiq#16866,
which adds the `alert_labels` feature to the core.