### PR TITLE
Do not raise an error when metrics are missing for one object

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context.rb
@@ -132,7 +132,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
     # @param key [String] the metrics key/group_id (e.g. cpu/usage).
     # @return [String] the metrics full key name (e.g. machine/example.com/cpu/usage).
     def get_metrics_key(raw_metrics, type, key)
-      raise CollectionFailure, "no #{type} metrics found for [#{@target.name}]" unless raw_metrics[type]
+      raise NoMetricsFoundError, "no #{type} metrics found for [#{@target.name}]" unless raw_metrics[type]
 
       # each object has only one metrics with some key/group_id ( e.g. each node has only one cpu/usage )
       raw_metrics[type].keys.find { |e| e.ends_with?(key) }

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
@@ -99,7 +99,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
 
     def sort_and_normalize(response, metric_title, conversion_factor)
       unless response["result"] && response["result"][0]
-        raise CollectionFailure, "[#{@target} #{@target.name}] No data in response"
+        raise NoMetricsFoundError, "[#{@target} #{@target.name}] No data in response"
       end
 
       response["result"][0]["values"].map do |x|


### PR DESCRIPTION
**Description**

Currently if a pod has no metrics data (for benign or malignant reasons) we:
a. raise an error and log a trace-log.
b. show users in the UI that metrics collection failed.

We want:
a. do not log missing data as an error ( usually this is benign behaviour of a pod not running )
b. do not show users an error message in the UI sammary page.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1530627

