### PR TITLE
recatch the metrics not found error

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -97,9 +97,9 @@ module ManageIQ::Providers
         begin
           context.collect_metrics
         rescue NoMetricsFoundError => e
-          _log.debug("Metrics unavailable: #{e.message}")
+          _log.warn("Metrics missing: [#{target_name}] #{e.message}")
         rescue StandardError => e
-          _log.error("Metrics unavailable: #{e.message}")
+          _log.error("Metrics unavailable: [#{target_name}] #{e.message}")
           ems.update_attributes(:last_metrics_error       => :unavailable,
                                 :last_metrics_update_date => Time.now.utc) if ems
           raise

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context.rb
@@ -213,7 +213,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
         #    "cpu/usage_rate" => "machine/<utl>/cpu/usage_rate"
         full_key = get_metrics_key(raw_metrics, 'gauge', key)
         unless full_key
-          raise CollectionFailure, "#{key} missing while query metrics"
+          raise NoMetricsFoundError, "#{key} missing while query metrics"
         end
 
         # insert the raw metrics into the @ts_values global object

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
@@ -93,6 +93,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
         metric_title,
         conversion_factor
       )
+    rescue NoMetricsFoundError
+      raise
     rescue StandardError => e
       raise CollectionFailure, "#{e.class.name}: #{e.message}"
     end


### PR DESCRIPTION
**Description**

In #227 I forgot to re-catch the `NoMetricsFoundError` and prevent it from escalating to `CollectionFailure`.

Fix for PR https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/227
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1530627