### PR TITLE
[WIP] Bump kubeclient to 3.0.z

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("hawkular-client",                 "~> 4.1")
   s.add_runtime_dependency("image-inspector-client",          "~>1.0.3")
-  s.add_runtime_dependency("kubeclient",                      "~> 2.5.2")
+  s.add_runtime_dependency("kubeclient",                      "~> 3.0.0")
   s.add_runtime_dependency("prometheus-alert-buffer-client",  "~> 0.2.0")
   s.add_runtime_dependency("prometheus-api-client",           "~> 0.6")
   s.add_runtime_dependency("more_core_extensions",            "~> 3.6")


### PR DESCRIPTION
Currently breaks bundle install:
```
Bundler could not find compatible versions for gem "recursive-open-struct":
  In Gemfile:
    manageiq-providers-kubernetes was resolved to 0.1.0, which depends on
      image-inspector-client (~> 1.0.3) was resolved to 1.0.3, which depends on
        recursive-open-struct (= 1.0.0)

    kubeclient was resolved to 3.0.0, which depends on
      recursive-open-struct (~> 1.0.4)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```
This is already fixed since https://github.com/moolitayer/image-inspector-client/pull/16, but there were no image-inspector-client releases since then.
Passes tests when run against image-inspector-client master.

- [ ] needs similar bump in manageiq repo
- [ ] needs similar bump in kubevirt repo

https://bugzilla.redhat.com/show_bug.cgi?id=1507528

cc @zeari @enoodle