### PR TITLE
Bump kubeclient to >=2.5.2 <2.6

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("hawkular-client",                 "~> 4.1")
   s.add_runtime_dependency("image-inspector-client",          "~>1.0.3")
-  s.add_runtime_dependency("kubeclient",                      "~>2.4.0")
+  s.add_runtime_dependency("kubeclient",                      "~> 2.5.2")
   s.add_runtime_dependency("prometheus-alert-buffer-client",  "~> 0.2.0")
   s.add_runtime_dependency("prometheus-api-client",           "~> 0.6")
 


### PR DESCRIPTION
- [x] core dependency relaxed to `~>2.4` https://github.com/ManageIQ/manageiq/pull/16957 
- [ ] simultaneous bump https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/26

https://bugzilla.redhat.com/show_bug.cgi?id=1507528

@miq-bot add-label bug, gaprindashvili/yes

(On master, we'll later upgrade to kubeclient 3.0.0, need to resolve a version conflict first. On gaprindashvili, we'll stay with 2.5.)

@zeari @jhernand please review.