### PR TITLE
abort container ssa if can't fetch metadata

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -142,7 +142,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     begin
       inspector_metadata = image_inspector_client.fetch_metadata
     rescue ImageInspectorClient::InspectorClientException => e
-      _log.error("analyzing image-inspector metadata for #{options[:docker_image_id]} failed with error: #{e}")
+      msg = "analyzing image-inspector metadata for #{options[:docker_image_id]} failed with error: #{e}"
+      _log.error(msg)
+      return queue_signal(:abort_job, msg, 'error')
     end
 
     if inspector_metadata.ImageAcquireError.present?


### PR DESCRIPTION
This will prevent issues and report correctly on event where the pod can't be accessed for some reason on that stage. This could happen for example if the pod is deleted by an external command.