### PR TITLE
bump image-inspector image version to 2.4

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -3,7 +3,7 @@ require 'kubeclient'
 
 class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   PROVIDER_CLASS = ManageIQ::Providers::Kubernetes::ContainerManager
-  INSPECTOR_IMAGE_TAG = '2.1'.freeze
+  INSPECTOR_IMAGE_TAG = '2.4'.freeze
   INSPECTOR_PORT = 8080
   DOCKER_SOCKET = '/var/run/docker.sock'
   SCAN_CATEGORIES = %w(system software)

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -296,7 +296,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
         pod = create_pod_definition
         expect(pod[:spec][:containers][0][:command]
           .select { |cmd| cmd.starts_with?("--cve-url=") }.first.split('=').last).to eq("cve_url1")
-        expect(pod[:spec][:containers][0][:image]).to eq("registry1/repository1:2.1")
+        expect(pod[:spec][:containers][0][:image]).to eq("registry1/repository1:2.4")
       end
     end
 


### PR DESCRIPTION
Use the new Image-Inspector image.

Main changelog for this version:
Enhancements:
* Can scan running containers
* Can use ClamAV Scanner
* Enable token authentication for web access
* Reports the status of image acquiring
* Support for authentication token to all endpoints

and many bugfixes.


Will solve a couple of BZs:

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1512824
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1484936

This will also allow us to move forward with another BZ https://bugzilla.redhat.com/show_bug.cgi?id=1524616 (which will also require a new version of image-inspector-client to be made..)