### PR TITLE
[WIP] disable use-docker-socket feature, remove docker socket from volumes

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -419,16 +419,13 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
               "--chroot",
               "--image=#{options[:image_full_name]}",
               "--scan-type=openscap",
-              "--serve=0.0.0.0:#{options[:pod_port]}"
+              "--serve=0.0.0.0:#{options[:pod_port]}",
+              "--use-docker-socket=false",
+              "--registry-cert-dir=/var/run/secrets/kubernetes.io/serviceaccount/"
             ],
             :ports           => [{:containerPort => options[:pod_port]}],
-            :securityContext => {:privileged =>  true},
-            :volumeMounts    => [
-              {
-                :mountPath => DOCKER_SOCKET,
-                :name      => "docker-socket"
-              }
-            ],
+            :securityContext => {:capabilities => {:add => ["SYS_CHROOT"]}},
+            :volumeMounts    => [],
             :env             => inspector_proxy_env_variables,
             :readinessProbe  => {
               "initialDelaySeconds" => 15,
@@ -440,12 +437,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
             }
           }
         ],
-        :volumes       => [
-          {
-            :name     => "docker-socket",
-            :hostPath => {:path => DOCKER_SOCKET}
-          }
-        ]
+        :volumes => []
       }
     }
 


### PR DESCRIPTION
This will use image inspector docker-less ability to fetch images, that will be added in https://github.com/openshift/image-inspector/pull/95


* requires the SYS_CHROOT capability for the pod