### PR TITLE
[WIP] add authentication to image inspector requests

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -253,9 +253,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
       :verify_mode => verify_ssl_mode,
       :cert_store  => ssl_cert_store,
     }
+    headers = client.headers
+    headers[:'X-Auth-Token'] = scan_data[:auth_token] if scan_data[:auth_token]
     MiqContainerGroup.new(pod_proxy + SCAN_CONTENT_PATH,
                           nethttp_options,
-                          client.headers.stringify_keys,
+                          headers.stringify_keys,
                           scan_data[:guest_os])
   end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -1,5 +1,17 @@
 require 'MiqContainerGroup/MiqContainerGroup'
 
+RSpec::Matchers.define :pod_env_containing do |expected|
+  match do |actual|
+    actual[:spec][:containers][0][:env][0][:name].include?(expected[:name]) && actual[:spec][:containers][0][:env][0][:value].include?(expected[:value])
+  end
+end
+
+RSpec::Matchers.define :hash_containing_string do |string|
+  match do |actual|
+    actual["args"] && actual["args"][0] && actual["args"][0].include?(string)
+  end
+end
+
 class MockKubeClient
   include ArrayRecursiveOpenStruct
 
@@ -214,10 +226,21 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
 
     context "completes successfully" do
       before(:each) do
+        allow(@job).to receive(:target_entity) { @image }
         allow_any_instance_of(described_class).to receive_messages(:collect_compliance_data) unless OpenscapResult.openscap_available?
 
         expect(@job.state).to eq 'waiting_to_start'
+        allow(Kubeclient::Resource).to receive(:new)
         @job.signal(:start)
+      end
+
+      it 'should create a pod spec with the auth_token environment variable' do
+        expect(Kubeclient::Resource).to have_received(:new).with(
+          pod_env_containing(
+            :name  => ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job::INSPECTOR_AUTH_TOKEN,
+            :value => @job.options[:auth_token]
+          )
+        )
       end
 
       it 'should report success' do
@@ -231,6 +254,14 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
         expect(@image.openscap_result).to be
         expect(@image.openscap_result.binary_blob.md5).to eq('d1f1857281573cd777b31d76e8529dc9')
         expect(@image.openscap_result.openscap_rule_results.count).to eq(213)
+      end
+
+      it 'should generate and store the image inspector auth_token' do
+        expect(@job.options[:auth_token]).not_to be_nil
+      end
+
+      it 'should pass the auth_token as a parameter to scan_metadata' do
+        expect(@image).to have_received(:scan_metadata).with(anything, hash_containing_string(@job.options[:auth_token]))
       end
     end
 


### PR DESCRIPTION
this PR leverages a new security feature in Image Inspector, which allows a custom authentication check using a shared secret.

The shared secret is initialized by passing the pod environment variable INSPECTOR_AUTH_TOKEN. HTTP requests send to the image inspector pod should be signed with the header "X-Auth-Token" whose value is the shared secret in order to authenticate.

Note that if Image Inspector does not find INSPECTOR_AUTH_TOKEN in the environment, it will skip performing this authentication check on HTTP requests.

- [ ] This depends on #234 to use new image-inspector that includes https://github.com/openshift/image-inspector/pull/38
- [x] This depends on #263 a new version of image-inspector-client released with https://github.com/moolitayer/image-inspector-client/pull/17 => #263 

resubmission of https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/104