### PR TITLE
Propagate userid through to create a scanning job with current userid

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -191,13 +191,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     :bearer
   end
 
-  def scan_job_create(entity)
-    check_policy_prevent(:request_containerimage_scan, entity, User.current_user.userid, :raw_scan_job_create)
+  def scan_job_create(entity, userid)
+    check_policy_prevent(:request_containerimage_scan, entity, userid, :raw_scan_job_create)
   end
 
   def raw_scan_job_create(target_class, target_id = nil, userid = nil, target_name = nil)
     raise MiqException::Error, _("target_class must be a class not an instance") if target_class.kind_of?(ContainerImage)
-    userid ||= User.current_user.userid
     Job.create_job(
       "ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job",
       :userid          => userid,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -164,7 +164,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
         # https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/54/files
         image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
         User.current_user = FactoryGirl.create(:user, :userid => "bob")
-        job = @ems.raw_scan_job_create(image.class, image.id)
+        job = @ems.raw_scan_job_create(image.class, image.id, User.current_user.userid)
         expect(job).to have_attributes(
           :dispatch_status => "pending",
           :state           => "waiting_to_start",

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -146,7 +146,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
     it ".scan_job_create" do
       image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
       User.current_user = FactoryGirl.create(:user, :userid => "bob")
-      job = @ems.raw_scan_job_create(image.class, image.id)
+      job = @ems.raw_scan_job_create(image.class, image.id, User.current_user.userid)
 
       expect(job.state).to eq("waiting_to_start")
       expect(job.status).to eq("ok")


### PR DESCRIPTION
Currently when a user creates a scanning job we require `User.current_user` to be some value other than nil. But, when scheduling a scan for some period of time and then logging out / session times out `User.current_user` turns `nil` which causes the scanning job to break.

~~This patch fixes the above behavior to fallback to default user `system`.~~

Now we propagate `userid` through MiqSchedule which solves this issue.

Depends on: https://github.com/ManageIQ/manageiq/pull/17264

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1559459

cc: @cben @zeari 