### PR TITLE
Skip hostname validation for virtualization manager

### DIFF
--- a/app/models/manageiq/providers/kubernetes/virtualization_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/virtualization_manager_mixin.rb
@@ -14,6 +14,10 @@ module ManageIQ::Providers::Kubernetes::VirtualizationManagerMixin
              :zone,
              :to        => :parent_manager,
              :allow_nil => true
+
+    def self.hostname_required?
+      false
+    end
   end
 
   module ClassMethods


### PR DESCRIPTION
When adding kubevirt provider with container provider at the same
request, there is no 'default' endpoint if the kubevirt provider is
added first. Therefore no need to check for hostname validation at that
point of time.