### PR TITLE
Change saver_strategy value to String

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
@@ -236,7 +236,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
           :association          => :container_services,
           :secondary_refs       => {:by_container_project_and_name => [:container_project, :name]},
           :attributes_blacklist => [:namespace],
-          :saver_strategy       => :default # TODO(perf) Can't use batch strategy because of usage of M:N container_groups relation
+          :saver_strategy       => "default" # TODO(perf) Can't use batch strategy because of usage of M:N container_groups relation
         )
       )
     initialize_custom_attributes_collections(@collections[:container_services], %w(labels selectors))

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,7 +60,7 @@
     :refresh_interval: 15.minutes
     :inventory_object_refresh: true
     :inventory_collections:
-      :saver_strategy: :batch
+      :saver_strategy: batch
 :workers:
   :worker_base:
     :event_catcher:

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -645,9 +645,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
     end
 
     [
-      {:saver_strategy => :default},
-      {:saver_strategy => :batch, :use_ar_object => true},
-      {:saver_strategy => :batch, :use_ar_object => false}
+      {:saver_strategy => "default"},
+      {:saver_strategy => "batch", :use_ar_object => true},
+      {:saver_strategy => "batch", :use_ar_object => false}
     ].each do |saver_options|
       context "with #{saver_options}" do
         before(:each) do

--- a/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -422,9 +422,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
     end
 
     [
-      {:saver_strategy => :default},
-      {:saver_strategy => :batch, :use_ar_object => true},
-      {:saver_strategy => :batch, :use_ar_object => false}
+      {:saver_strategy => "default"},
+      {:saver_strategy => "batch", :use_ar_object => true},
+      {:saver_strategy => "batch", :use_ar_object => false}
     ].each do |saver_options|
       context "with #{saver_options}" do
         before(:each) do


### PR DESCRIPTION
Symbols in configuration values are problematic because Symbols do not
roundtrip through JSON.  Since the API now exposes Settings, it's not
possible to set Symbols as values.  The saver_strategy was fixed in
https://github.com/ManageIQ/manageiq/pull/17168 to support String
values, and the next step is to remove all Symbols from the Settings.

https://github.com/ManageIQ/manageiq/issues/17201
https://bugzilla.redhat.com/show_bug.cgi?id=1558031