### PR TITLE
Add a config option to force legacy hawkular collector

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -80,5 +80,6 @@
             :metrics_path: "/hawkular/metrics"
             :prometheus_open_timeout: 5
             :prometheus_request_timeout: 30
+            :hawkular_force_legacy: false
         :ems_refresh_worker:
           :ems_refresh_worker_kubernetes: {}


### PR DESCRIPTION
**Description**
Add a config option to force legacy hawkular collector

This PR adds an option to force using old endpoint for metrics capture from Hawkular.

evm => configuration => advanced

**Screenshot** 
![force-legacy-hawkular](https://user-images.githubusercontent.com/2181522/38818173-c4e830f4-41a2-11e8-960f-74f3888f183b.png)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1562090