### PR TITLE
mapping.tag is a category Tag, calling .category is ill-defined

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -23,7 +23,7 @@ shared_examples "kubernetes refresher VCR tests" do
   # Smoke test the use of ContainerLabelTagMapping during refresh.
   before :each do
     mapping = FactoryGirl.create(:tag_mapping_with_category, :label_name => 'name')
-    @name_category = mapping.tag.category
+    @name_category = mapping.tag.classification
 
     @user_tag = FactoryGirl.create(:classification_cost_center_with_tags).entries.first.tag
   end


### PR DESCRIPTION
There are category/entry Tags, and category/entry Classifications.
```
                                   .parent
 category Classification "cat"   <----------   entry Classification "ent"
           |^                ^                        |^
       .tag||.classification  \_______________    .tag||.classification
           v|                     .category   \       v|
 category Tag /managed/cat                     entry Tag /managed/cat/ent
```
`.category` is supposed to get the "uncle", the category Classification from an *entry* Tag.

`mapping.tag` is a category Tag (for any-value mappings which are the kind we use).
Currently `.category` on a category Tag ("/managed/cat") happens to work same as `.classification`, but it's ill-defined and will stop working after https://github.com/ManageIQ/manageiq/pull/17418.