### PR TITLE
Respect kubevirt token if provided

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -81,8 +81,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
   def verify_kubevirt_credentials
     ensure_infra_manager
-    infra_manager.verify_credentials
-    infra_manager.verify_virt_supported
+    options = {
+      :token => authentication_token(:kubevirt),
+    }
+    infra_manager.verify_credentials(:kubevirt, options)
+    infra_manager.verify_virt_supported(options)
   end
 
   # UI methods for determining availability of fields


### PR DESCRIPTION
When changing the kubevirt's token under the virtualization tab, the new
token should be used for the validation check instead of the existing token.

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/77

Depends on https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/81