### PR TITLE
Default to force Hawkular legacy metrics collector

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -80,6 +80,6 @@
             :metrics_path: "/hawkular/metrics"
             :prometheus_open_timeout: 5
             :prometheus_request_timeout: 30
-            :hawkular_force_legacy: false
+            :hawkular_force_legacy: true
         :ems_refresh_worker:
           :ems_refresh_worker_kubernetes: {}

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -2,13 +2,13 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
   before do
     # @miq_server is required for worker_settings to work
     @miq_server = EvmSpecHelper.local_miq_server(:is_master => true)
-    @hawkular_force_legacy_settings = {
+    @hawkular_force_legacy_settings_false = {
       :workers => {
         :worker_base => {
           :queue_worker_base => {
             :ems_metrics_collector_worker => {
               :ems_metrics_collector_worker_kubernetes => {
-                :hawkular_force_legacy => true
+                :hawkular_force_legacy => false
               }
             }
           }
@@ -84,6 +84,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
     end
 
     it "detect hawkular metrics provider without m metric endpoint" do
+      stub_settings_merge(@hawkular_force_legacy_settings_false)
       allow_any_instance_of(described_class::HawkularCaptureContext)
         .to receive(:m_endpoint?)
         .and_return(false)
@@ -100,6 +101,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
     end
 
     it "detect hawkular metrics provider" do
+      stub_settings_merge(@hawkular_force_legacy_settings_false)
       allow_any_instance_of(described_class::HawkularCaptureContext)
         .to receive(:m_endpoint?)
         .and_return(true)
@@ -116,7 +118,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
     end
 
     it "detect hawkular metrics provider, force legacy collector" do
-      stub_settings_merge(@hawkular_force_legacy_settings)
       allow_any_instance_of(described_class::HawkularCaptureContext)
         .to receive(:m_endpoint?)
         .and_return(true)


### PR DESCRIPTION
**Description**
As discussed in BZ's 1580816 and 1572022 we want to default to legacy Hawkular metrics collector.
Users that are sure they have compatible Hawkular install will still be able to use the new collector by setting the config parameter to false.

**Screenshot**
![screenshot-localhost 3000-2018-05-24-09-40-39](https://user-images.githubusercontent.com/2181522/40468622-9f6d30c0-5f36-11e8-8bf5-9bbf95d1d8e2.png)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1580816