### PR TITLE
Kubevirt should report its own status

### DIFF
--- a/app/models/manageiq/providers/kubernetes/virtualization_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/virtualization_manager_mixin.rb
@@ -7,7 +7,6 @@ module ManageIQ::Providers::Kubernetes::VirtualizationManagerMixin
     delegate :authentication_check,
              :authentication_for_summary,
              :authentication_status,
-             :authentication_status_ok,
              :authentication_token,
              :authentications,
              :endpoints,


### PR DESCRIPTION
The UI expects each provider to report its status.
Since kubevirt uses its own token, it might be valid while the container
provider is invalid.

That causes the default_auth_status in the UI [1] to report a failed
status when editing the kubevirt provider as an infrastructure provider,
since it refers to the status of the parent container manager. As a
result of that failure, the dialog cannot be saved.

For that purpose, the delegated call to authentication_status_ok? should
be implemented on the kubevirt provider side.

[1] https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/ems_common_angular.rb#L861

Provider's PR is here:
https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/92

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/71