### PR TITLE
Kubevirt should reports its auth status

### DIFF
--- a/app/models/manageiq/providers/kubernetes/virtualization_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/virtualization_manager_mixin.rb
@@ -6,7 +6,6 @@ module ManageIQ::Providers::Kubernetes::VirtualizationManagerMixin
   included do
     delegate :authentication_check,
              :authentication_for_summary,
-             :authentication_status,
              :authentication_token,
              :authentications,
              :endpoints,


### PR DESCRIPTION
In addition to aca446f6561f34179519688a7540e93d85d25096 [1], another
authentication related method can be directed to kubevirt instead being
delegated to its parent provider.

[1] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/259

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/35