### PR TITLE
Bump image-inspector-client to 2.y.z

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_runtime_dependency("hawkular-client",                 "~> 4.1")
-  s.add_runtime_dependency("image-inspector-client",          "~>1.0.3")
+  s.add_runtime_dependency("image-inspector-client",          "~> 2.0")
   s.add_runtime_dependency("kubeclient",                      "~> 2.5.2")
   s.add_runtime_dependency("prometheus-alert-buffer-client",  "~> 0.2.0")
   s.add_runtime_dependency("prometheus-api-client",           "~> 0.6")


### PR DESCRIPTION
- Necessary for authentication to image inspector requests #239, https://bugzilla.redhat.com/show_bug.cgi?id=1524616
- Necessary to allow us to bump kubeclient (old image-inspector-client had hard req on `recursive-open-struct =1.0.0`).

It has no changelog and unfortunately no version tags but 1.0.3 was bumped in commit https://github.com/openshift/image-inspector-client-ruby/commit/8cca3744c188952d69635f803bf36cbcd72e6fed.
```
$ tig 8cca3744c188952d69635f803bf36cbcd72e6fed..HEAD 

f8b5215 2018-05-28 15:25 mtayer   ●─╮ [master] {origin/master} {origin/HEAD} <2.0.0> Merge pull request #4 from moolitayer/version_bump
ac0fb45 2018-05-28 12:29 mtayer   │ ● Bump to 2.0.0
d4a6ff4 2018-05-28 15:24 mtayer   ●─│─╮ Merge pull request #3 from cben/recursive-open-struct-1.y
20056d6 2018-05-28 12:04 cben     │ │ ● {cben/recursive-open-struct-1.y} Relax recursive-open-struct from 1.0.z to 1.y.z
c94da51 2018-05-28 15:24 mtayer   ●─│─│─╮ Merge pull request #1 from moolitayer/patch-1
372cc12 2017-08-15 17:46 mtayer   │ │ │ ● Updates post moving the project under Openshift
8ffdb0c 2018-03-21 12:41 mtayer   ●─┼─╯ │ Merge pull request #2 from moolitayer/bump_versions
a8e2c12 2018-02-04 13:01 mtayer   │ ● ╭─╯ {origin/bump_versions} Address rubocop comments
62f0564 2018-02-04 12:49 mtayer   │ ● │ Bump and set dependency versions
702fbe4 2018-02-04 12:47 mtayer   │ ● │ Bump requiered rubies
5a0915b 2018-02-04 12:44 mtayer   │ ● │ Fix gem name in comment
b6d20b6 2017-08-03 12:46 mtayer   ●─┼─╯ Merge pull request #19 from cben/patch-1
080d912 2017-08-03 12:03 cben     │ ● {cben/patch-1} Update links to openshift/image-inspector
30b714d 2017-07-17 18:45 mtayer   ●─┤ Merge pull request #17 from ilackarms/master
3a7abc9 2017-04-05 17:22 sdw35    │ ● fix typo
d9e956d 2017-04-05 16:01 sdw35    │ ● move auth token within the auth_options hash
3b201c6 2017-04-03 15:36 sdw35    │ ● change string hash key to symbol hash key
9eb39cb 2017-03-30 19:28 sdw35    │ ● add option for passing in auth token
1da5113 2017-05-07 12:12 mtayer   ●─┤ Merge pull request #18 from jrafanie/add_ruby24_to_travis
f3cc013 2017-05-05 17:57 jrafanie │ ● Add ruby 2.4 support in travis.
1855a82 2017-03-07 14:14 mtayer   ●─┤ Merge pull request #16 from moolitayer/relax_dep
cede524 2017-03-05 14:12 mtayer   │ ● {cben/relax_dep} {origin/relax_dep} Relax requirement on recursive-open-struct
32ee8ec 2017-02-14 10:55 mtayer   ●─┤ Merge pull request #15 from cben/plus-nil
f50e491 2017-02-08 14:15 cben     │ ● {cben/plus-nil} InspectorClientException#to_s: don't crash without message
1c6878f 2016-12-05 14:55 mtayer   ●─┤ {cben/master} Merge pull request #14 from moolitayer/update_travis_ruby
9546bd7 2016-04-09 14:02 mtayer   │ ● {cben/update_travis_ruby} {origin/update_travis_ruby} Add ruby 2.3 to travis.yml
```

Of these, the only functional changes are:
- https://github.com/moolitayer/image-inspector-client/pull/17
  > these changes update client to send proper authentication token in request headers (see change in openshift/image-inspector#38)

  ~~Ooh, so sounds like bumping to new image-inspector (#234) depends on using this new client (?)~~
  EDIT: apparently not.  But #239 depends on both bumps.

- https://github.com/moolitayer/image-inspector-client/pull/15 (minor, better reporting of exceptions)

@moolitayer Does this require any code changes?  Did you release as 2.0.0 because of any known incompatibility?

@moolitayer @nimrodshn @zeari What testing does this require before merging?
