### PR TITLE
Set EmsEvent ems_ref to event's uid, to avoid same-second collision

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -66,7 +66,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
       :namespace => event.object.involvedObject.namespace,
       :reason    => event.object.reason,
       :message   => event.object.message,
-      :uid       => event.object.involvedObject.uid
+      :uid       => event.object.involvedObject.uid,
+      :event_uid => event.object.metadata.uid,
     }
 
     unless event.object.involvedObject.fieldPath.nil?

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_parser_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_parser_mixin.rb
@@ -24,7 +24,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventParserMixin
         :container_namespace       => event[:container_namespace],
         :container_name            => event[:container_name],
         :full_data                 => event,
-        :ems_id                    => ems_id
+        :ems_id                    => ems_id,
+        :ems_ref                   => event[:event_uid],
       }
 
       event_hash[ems_ref_key] = event[:uid]

--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -77,7 +77,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           :container_name       => 'heapster',
           :container_group_name => 'heapster-aas69',
           :container_namespace  => 'openshift-infra',
-          :event_type           => 'POD_KILLING'
+          :event_type           => 'POD_KILLING',
+          :event_uid            => 'fa735ca9-4f7d-11e6-b177-525400c7c086',
         }
         event = array_recursive_ostruct(:object => kubernetes_event)
         expect(test_class.new.extract_event_data(event)).to eq(expected_data)
@@ -162,7 +163,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           :uid                       => '7599d451-4c1c-11e6-89dd-525400c7c086',
           :container_replicator_name => 'mysql-1',
           :container_namespace       => 'proj',
-          :event_type                => 'REPLICATOR_SUCCESSFULCREATE'
+          :event_type                => 'REPLICATOR_SUCCESSFULCREATE',
+          :event_uid                 => '4c513e6d-525d-11e6-8564-525400c7c086',
         }
         event = array_recursive_ostruct(:object => kubernetes_event)
         expect(test_class.new.extract_event_data(event)).to eq(expected_data)
@@ -213,7 +215,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
                                   'c75d2b66-6d5b-49e0-b906-1d8abaf3e73b',
           :uid                 => 'd30a880d-dfa7-11e5-af89-525400c7c086',
           :container_node_name => 'vm-test-03.example.com',
-          :event_type          => 'NODE_REBOOTED'
+          :event_type          => 'NODE_REBOOTED',
+          :event_uid           => 'a4b92ae1-5251-11e6-8564-525400c7c086',
         }
       end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1583832
@miq-bot add-label bug, events, gaprindashvili/yes

EmsEvent.create_event drops "duplicate" events, determined by (event_type, timestamp, chain_id, ems_id, ems_ref).
Container events had no ems_ref (and no chain_id), meaning events of same type in same second collided and only one EmsEvent was created.
The lost events weren't handled by Automate / Policy.

Using k8s event's uid, not involvedObject's uid which still wouldn't be unique (for repeating events on same object).

- [x] Tested Automate runs 4 times for scaling from 0 to 4 pods.
  4 EmsEvents created, with same timestamp and different ems_ref and.
- [ ] TODO: same test on gaprindashvili.

@elad661 @moolitayer please review