### PR TITLE
Persister: InventoryCollection building through add_collection()

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
@@ -408,7 +408,6 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
     lambda do |inventory_collection, inventory_objects_index, attributes_index|
       relation = inventory_collection.model_class.where(:ems_id => inventory_collection.parent.id).archived
 
-
       # Skip reconnect if there are no archived entities
       return if relation.archived.count <= 0
       raise "Allowed only manager_ref size of 1, got #{inventory_collection.manager_ref}" if inventory_collection.manager_ref.count > 1

--- a/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/inventory_collections.rb
@@ -408,6 +408,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
     lambda do |inventory_collection, inventory_objects_index, attributes_index|
       relation = inventory_collection.model_class.where(:ems_id => inventory_collection.parent.id).archived
 
+
       # Skip reconnect if there are no archived entities
       return if relation.archived.count <= 0
       raise "Allowed only manager_ref size of 1, got #{inventory_collection.manager_ref}" if inventory_collection.manager_ref.count > 1

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -64,7 +64,7 @@ module ManageIQ::Providers::Kubernetes
     end
 
     def persister_inv_to_persister(persister, inventory, options)
-      persister.add_collection(@tag_mapper.tags_to_resolve_collection)
+      persister.add_collection_directly(@tag_mapper.tags_to_resolve_collection)
       # TODO(lsmola) expose persister and use that and use that instead of @inv_collections
       @inv_collections = persister.collections
 

--- a/app/models/manageiq/providers/kubernetes/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister.rb
@@ -1,4 +1,8 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Persister < ManagerRefresh::Inventory::Persister
   require_nested :ContainerManager
   require_nested :TargetCollection
+
+  def add_collection_directly(collection)
+    @collections[collection.name] = collection
+  end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister.rb
@@ -5,4 +5,12 @@ class ManageIQ::Providers::Kubernetes::Inventory::Persister < ManagerRefresh::In
   def add_collection_directly(collection)
     @collections[collection.name] = collection
   end
+
+  # ManagerRefresh::InventoryCollection.inventory_object_attributes
+  # are not defined
+  def make_builder_settings(extra_settings = {})
+    opts = super
+    opts[:auto_inventory_attributes] = false
+    opts
+  end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager.rb
@@ -6,10 +6,6 @@ class ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager < 
     initialize_container_inventory_collections
   end
 
-  def add_collection_directly(collection)
-    @collections[collection.name] = collection
-  end
-
   protected
 
   def targeted?

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager.rb
@@ -1,3 +1,30 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister
-  include ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
+  # include ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
+  include ManageIQ::Providers::Kubernetes::Inventory::Persister::Definitions::ContainerCollections
+
+  def initialize_inventory_collections
+    initialize_container_inventory_collections
+  end
+
+  def add_collection_directly(collection)
+    @collections[collection.name] = collection
+  end
+
+  protected
+
+  def targeted?
+    false
+  end
+
+  def strategy
+    nil
+  end
+
+  def shared_options
+    {
+      :strategy => strategy,
+      :targeted => targeted?,
+      :parent   => manager.presence
+    }
+  end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister
-  # include ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
   include ManageIQ::Providers::Kubernetes::Inventory::Persister::Definitions::ContainerCollections
 
   def initialize_inventory_collections

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/definitions/container_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/definitions/container_collections.rb
@@ -1,0 +1,130 @@
+module ManageIQ::Providers::Kubernetes::Inventory::Persister::Definitions::ContainerCollections
+  extend ActiveSupport::Concern
+
+  def initialize_container_inventory_collections
+    %i(containers
+       container_builds
+       container_build_pods
+       container_env_vars
+       container_groups
+       container_images
+       container_image_registries
+       container_limits
+       container_limit_items
+       container_nodes
+       container_port_configs
+       container_projects
+       container_quotas
+       container_quota_scopes
+       container_quota_items
+       container_volumes
+       container_replicators
+       container_routes
+       container_services
+       container_service_port_configs
+       container_templates
+       container_template_parameters
+       computer_systems
+       computer_system_hardwares
+       computer_system_operating_systems
+       persistent_volumes
+       persistent_volume_claims
+       security_contexts).each do |name|
+
+      add_collection(container, name)
+    end
+
+
+
+    initialize_custom_attributes_collections(@collections[:container_projects], %w(labels additional_attributes))
+    initialize_taggings_collection(@collections[:container_projects])
+
+    initialize_container_conditions_collection(manager, :container_nodes)
+    initialize_custom_attributes_collections(@collections[:container_nodes], %w(labels additional_attributes))
+    initialize_taggings_collection(@collections[:container_nodes])
+
+    initialize_container_conditions_collection(manager, :container_groups)
+    initialize_custom_attributes_collections(@collections[:container_groups], %w(labels node_selectors))
+    initialize_taggings_collection(@collections[:container_groups])
+
+    initialize_custom_attributes_collections(@collections[:container_replicators], %w(labels selectors))
+    initialize_taggings_collection(@collections[:container_replicators])
+
+    initialize_custom_attributes_collections(@collections[:container_services], %w(labels selectors))
+    initialize_taggings_collection(@collections[:container_services])
+
+    initialize_custom_attributes_collections(@collections[:container_routes], %w(labels))
+    initialize_taggings_collection(@collections[:container_routes])
+
+    initialize_custom_attributes_collections(@collections[:container_templates], %w(labels))
+    initialize_taggings_collection(@collections[:container_templates])
+
+    initialize_custom_attributes_collections(@collections[:container_builds], %w(labels))
+    initialize_taggings_collection(@collections[:container_builds])
+
+    initialize_custom_attributes_collections(@collections[:container_build_pods], %w(labels))
+
+  end
+
+  # ContainerCondition is polymorphic child of ContainerNode & ContainerGroup.
+  def initialize_container_conditions_collection(manager, association)
+    relation = manager.public_send(association)
+    query = ContainerCondition.where(
+      :container_entity_type => relation.model.base_class.name,
+      :container_entity_id   => relation, # nested SELECT. TODO: compare to a JOIN.
+      )
+    @collections[[:container_conditions_for, relation.model.base_class.name]] =
+      ::ManagerRefresh::InventoryCollection.new(
+        shared_options.merge(
+          :model_class => ContainerCondition,
+          :name        => "container_conditions_for_#{association}".to_sym,
+          :arel        => query,
+          :manager_ref => [:container_entity, :name],
+          )
+      )
+  end
+
+  # CustomAttribute is polymorphic child of many models
+  def initialize_custom_attributes_collections(parent_collection, sections)
+    type = parent_collection.model_class.base_class.name
+    relation = parent_collection.full_collection_for_comparison
+    sections.each do |section|
+      query = CustomAttribute.where(
+        :resource_type => type,
+        :resource_id   => relation,
+        :section       => section.to_s
+      )
+      @collections[[:custom_attributes_for, type, section.to_s]] =
+        ::ManagerRefresh::InventoryCollection.new(
+          shared_options.merge(
+            :model_class                  => CustomAttribute,
+            :name                         => "custom_attributes_for_#{parent_collection.name}_#{section}".to_sym,
+            :arel                         => query,
+            :manager_ref                  => [:resource, :section, :name],
+            :parent_inventory_collections => [parent_collection.name],
+            )
+        )
+    end
+  end
+
+  def initialize_taggings_collection(parent_collection)
+    type = parent_collection.model_class.base_class.name
+    relation = parent_collection.full_collection_for_comparison
+    query = Tagging.where(
+      :taggable_type => type,
+      :taggable_id   => relation,
+      ).joins(:tag).merge(Tag.controlled_by_mapping)
+
+    @collections[[:taggings_for, type]] =
+      ::ManagerRefresh::InventoryCollection.new(
+        shared_options.merge(
+          :model_class                  => Tagging,
+          :name                         => "taggings_for_#{parent_collection.name}".to_sym,
+          :arel                         => query,
+          :manager_ref                  => [:taggable, :tag],
+          :parent_inventory_collections => [parent_collection.name],
+          )
+      )
+  end
+
+end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/target_collection.rb
@@ -1,16 +1,15 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Persister::TargetCollection < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
-  def targeted
+  def targeted?
     false # TODO(lsmola) get ready for true, which means a proper targeted refresh. That will require more effort.
   end
 
   def shared_options
-    settings_options = options[:inventory_collections].try(:to_hash) || {}
-
-    settings_options.merge(
-      :targeted => targeted,
+    {
+      :targeted => targeted?,
       :complete => false, # For now, we want to a only create and update elements using watches data, delete events could
       # probably set finished_at and deleted_on dates, as an update based disconnect_inv.
       :strategy => :local_db_find_missing_references, # By default no IC will be saved
-    )
+      :parent   => manager.presence
+    }
   end
 end


### PR DESCRIPTION
**Issue**: https://github.com/ManageIQ/manageiq/issues/17396
- [x] (**depends on**) PR: https://github.com/ManageIQ/manageiq/pull/17621

- **dependent**: https://github.com/ManageIQ/manageiq-providers-openshift/pull/100

New Interface for definition/creating InventoryCollection from persister.
Using add_collection() instead of add_inventory_collection() to build collections.

Builder classes are defined on core project, provider specific InventoryCollections specified in concerns