### PR TITLE
Stop falling back to old_ems_id

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_mixin.rb
@@ -6,7 +6,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
       @ends = end_time.to_i.in_milliseconds if end_time
       @interval = interval.to_i
       @tenant = target.try(:container_project).try(:name) || '_system'
-      @ext_management_system = @target.ext_management_system || @target.try(:old_ext_management_system)
+      @ext_management_system = @target.ext_management_system
       @ts_values = Hash.new { |h, k| h[k] = {} }
       @metrics = []
 


### PR DESCRIPTION
@miq-bot add-label technical debt
A step towards https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/196.

`ems_id` is always set since we switched to soft delete.  `ems_id` got backfilled from `old_ems_id` for old disconnected records too by https://github.com/ManageIQ/manageiq-schema/pull/18.

@zeari @Ladas please review