### PR TITLE
bin/setup - create manageiq/log manually

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -9,7 +9,7 @@ unless gem_root.join("spec/manageiq").exist?
 end
 
 # ensure a log dir always exists
-system "mkdir -p spec/manageiq/log"
+gem_root.join("spec/manageiq/log").mkpath
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
 ManageIQ::Environment.manageiq_plugin_setup(gem_root)

--- a/bin/setup
+++ b/bin/setup
@@ -8,5 +8,8 @@ unless gem_root.join("spec/manageiq").exist?
   system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
 end
 
+# ensure a log dir always exists
+system "mkdir -p spec/manageiq/log"
+
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
 ManageIQ::Environment.manageiq_plugin_setup(gem_root)


### PR DESCRIPTION
Similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/4502, https://github.com/ManageIQ/manageiq-providers-nuage/pull/130.

Since https://github.com/ManageIQ/manageiq/pull/17663, there is no manageiq/log directory by default.
This breaks Travis e.g. https://travis-ci.org/ManageIQ/manageiq-providers-kubernetes/jobs/418623069

@miq-bot add-label bug, developer, test

@kbrock @himdel @miha-plesko please review