### PR TITLE
Move streaming_refresh_enabled method

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -18,6 +18,10 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     supports :streaming_refresh do
       unsupported_reason_add(:streaming_refresh, "Streaming refresh not enabled") unless streaming_refresh_enabled?
     end
+
+    def streaming_refresh_enabled?
+      Settings.ems_refresh[emstype.to_sym]&.streaming_refresh
+    end
   end
 
   def monitoring_manager_needed?
@@ -28,10 +32,6 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
   def supports_metrics?
     endpoints.where(:role => METRICS_ROLES).exists?
-  end
-
-  def streaming_refresh_enabled?
-    Settings.ems_refresh[emstype.to_sym]&.streaming_refresh
   end
 
   module ClassMethods


### PR DESCRIPTION
Move the method which checks if streaming_refresh is enabled in config
closer to the supports :streaming_refresh block.

Ref: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/271#discussion_r211266196