### PR TITLE
Fix watches when using service catalog endpoint

### DIFF
--- a/app/models/manageiq/providers/kubernetes/inventory/collector/watches.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/watches.rb
@@ -12,4 +12,12 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::Watches < ManageIQ:
   def pods
     @pods ||= notices['Pod']&.map { |notice| notice.object } || []
   end
+
+  def cluster_service_offerings
+    []
+  end
+
+  def cluster_service_parameters_sets
+    []
+  end
 end


### PR DESCRIPTION
Using watches with the service catalog endpoint is failing when it goes to parse a watch update.  Eventually we should use watches for the services but not up to that yet