### PR TITLE
Use discover to catch service catalog

### DIFF
--- a/app/models/manageiq/providers/kubernetes/inventory/collector/watches.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/watches.rb
@@ -12,4 +12,12 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::Watches < ManageIQ:
   def pods
     @pods ||= notices['Pod']&.map { |notice| notice.object } || []
   end
+
+  def cluster_service_offerings
+    []
+  end
+
+  def cluster_service_parameters_sets
+    []
+  end
 end


### PR DESCRIPTION
Rather than waiting to call Kubeclient::Client#get_entity_type for
the 404 exception we can call Kubeclient::Client#discover and catch the
exception when connecting.

- [x] Depends on: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/283