### PR TITLE
Streaming refresh for service catalog entities

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/streaming_refresh_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/streaming_refresh_mixin.rb
@@ -30,7 +30,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::StreamingRefreshMixin
   def setup_streaming_refresh
     self.initial           = true
     self.queue             = Queue.new
-    self.resource_versions = {}
+    self.resource_versions = Concurrent::Map.new
     self.watch_streams     = Concurrent::Map.new
     self.watch_threads     = Concurrent::Map.new
   end

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -140,7 +140,13 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   end
 
   def connect(options = {})
-    effective_options = options.merge(
+    effective_options = connect_options(options)
+
+    self.class.raw_connect(effective_options[:hostname], effective_options[:port], effective_options)
+  end
+
+  def connect_options(options = {})
+    options.merge(
       :hostname    => options[:hostname] || address,
       :port        => options[:port] || port,
       :user        => options[:user] || authentication_userid(options[:auth_type]),
@@ -152,7 +158,6 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
         :cert_store => ssl_cert_store
       }
     )
-    self.class.raw_connect(effective_options[:hostname], effective_options[:port], effective_options)
   end
 
   def authentications_to_validate

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
@@ -17,12 +17,12 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager < 
     @pods ||= connection.get_pods
   end
 
-  def cluster_service_offerings
-    @cluster_service_offerings ||= service_catalog_connection&.get_cluster_service_classes || []
+  def cluster_service_classes
+    @cluster_service_classes ||= service_catalog_connection&.get_cluster_service_classes || []
   end
 
-  def cluster_service_parameters_sets
-    @cluster_service_parameters_sets ||= service_catalog_connection&.get_cluster_service_plans || []
+  def cluster_service_plans
+    @cluster_service_plans ||= service_catalog_connection&.get_cluster_service_plans || []
   end
 
   private

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/watches.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/watches.rb
@@ -13,11 +13,11 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::Watches < ManageIQ:
     @pods ||= notices['Pod']&.map { |notice| notice.object } || []
   end
 
-  def cluster_service_offerings
+  def cluster_service_classes
     []
   end
 
-  def cluster_service_parameters_sets
+  def cluster_service_plans
     []
   end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/watches.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/watches.rb
@@ -14,10 +14,10 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::Watches < ManageIQ:
   end
 
   def cluster_service_classes
-    []
+    @cluster_service_classes ||= notices['ClusterServiceClass']&.map { |notice| notice.object } || []
   end
 
   def cluster_service_plans
-    []
+    @cluster_service_plans ||= notices['ClusterServicePlan']&.map { |notice| notice.object } || []
   end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -4,8 +4,8 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     parse_pods(collector.pods)
 
     # Service catalog entities
-    parse_service_offerings(collector.cluster_service_offerings)
-    parse_service_parameters_sets(collector.cluster_service_parameters_sets)
+    parse_service_classes(collector.cluster_service_classes)
+    parse_service_plans(collector.cluster_service_plans)
   end
 
   private
@@ -38,41 +38,41 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     )
   end
 
-  def parse_service_offerings(service_offeringes)
-    service_offeringes.each do |service_offering|
-      parse_service_offering(service_offering)
+  def parse_service_classes(service_classes)
+    service_classes.each do |service_class|
+      parse_service_class(service_class)
     end
   end
 
-  def parse_service_offering(service_offering)
+  def parse_service_class(service_class)
     persister.service_offerings.build(
-      :name        => service_offering.spec.externalName,
-      :ems_ref     => service_offering.spec.externalID,
-      :description => service_offering.spec.description,
+      :name        => service_class.spec.externalName,
+      :ems_ref     => service_class.spec.externalID,
+      :description => service_class.spec.description,
       :extra       => {
-        :metadata => service_offering.metadata,
-        :spec     => service_offering.spec,
-        :status   => service_offering.status
+        :metadata => service_class.metadata,
+        :spec     => service_class.spec,
+        :status   => service_class.status
       }
     )
   end
 
-  def parse_service_parameters_sets(service_parameters_sets)
-    service_parameters_sets.each do |service_parameters_set|
-      parse_service_parameters_set(service_parameters_set)
+  def parse_service_plans(service_plans)
+    service_plans.each do |service_plan|
+      parse_service_plan(service_plan)
     end
   end
 
-  def parse_service_parameters_set(service_parameters_set)
+  def parse_service_plan(service_plan)
     persister.service_parameters_sets.build(
-      :name             => service_parameters_set.spec.externalName,
-      :ems_ref          => service_parameters_set.spec.externalID,
-      :description      => service_parameters_set.spec.description,
-      :service_offering => persister.service_offerings.lazy_find(service_parameters_set.spec.clusterServiceClassRef.name),
+      :name             => service_plan.spec.externalName,
+      :ems_ref          => service_plan.spec.externalID,
+      :description      => service_plan.spec.description,
+      :service_offering => persister.service_offerings.lazy_find(service_plan.spec.clusterServiceClassRef.name),
       :extra            => {
-        :metadata => service_parameters_set.metadata,
-        :spec     => service_parameters_set.spec,
-        :status   => service_parameters_set.status
+        :metadata => service_plan.metadata,
+        :spec     => service_plan.spec,
+        :status   => service_plan.status
       }
     )
   end


### PR DESCRIPTION
This adds the service_catalog entity types to the list of watched entities.

1. I had to change the collector methods from cluster_service_offerings and cluster_service_parameters_sets to the native entity type so that i could get the resourceVersion with the entity type from the collection.
2. I moved from using `ems.connect` to saving the connect options and using raw_connect so that each thread didn't require an ActiveRecord connection.  With 5 threads I was exhausting the number of connections in the connection pool.

Dependent: https://github.com/ManageIQ/manageiq-providers-openshift/pull/113