### PR TITLE
Discover API endpoint in kubernetes_connection

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -42,7 +42,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     def kubernetes_connect(hostname, port, options)
       require 'kubeclient'
 
-      Kubeclient::Client.new(
+      conn = Kubeclient::Client.new(
         raw_api_endpoint(hostname, port, options[:path]),
         options[:version] || kubernetes_version,
         :ssl_options    => Kubeclient::Client::DEFAULT_SSL_OPTIONS.merge(options[:ssl_options] || {}),
@@ -53,6 +53,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
           :read => Settings.ems.ems_kubernetes.read_timeout.to_f_with_method
         }
       )
+
+      # Test the API endpoint at connect time to prevent exception being raised
+      # on first method call
+      conn.discover
+
+      conn
     end
 
     def kubernetes_auth_options(options)

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
@@ -28,19 +28,16 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager < 
   private
 
   def connection
-    @connection ||= manager.connect(:service => "kubernetes")
+    @connection ||= connect("kubernetes")
   end
 
   def service_catalog_connection
-    @service_catalog_connection ||=
-      begin
-        manager.connect(:service => "kubernetes_service_catalog").tap do |client|
-          # Calling discover on the Client will fail early if the service catalog
-          # endpoint isn't configured.
-          client.discover
-        end
-      rescue KubeException
-        nil
-      end
+    @service_catalog_connection ||= connect("kubernetes_service_catalog")
+  end
+
+  def connect(service)
+    manager.connect(:service => service)
+  rescue KubeException
+    nil
   end
 end


### PR DESCRIPTION
Call discover when connecting to a kubernetes endpoint to prevent exceptions on future method calls.