### PR TITLE
Fix MetricsCapture and Refresher specs failing due to a missing zone

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :ems_kubernetes_with_zone, :parent => :ems_kubernetes do
+    zone do
+      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone
+    end
+  end
+end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_capture_context_spec.rb
@@ -1,11 +1,10 @@
 describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::HawkularCaptureContext do
   before(:each) do
-    allow(MiqServer).to receive(:my_zone).and_return("default")
     hostname = 'capture.context.com'
     token = 'theToken'
 
     @ems = FactoryGirl.create(
-      :ems_kubernetes,
+      :ems_kubernetes_with_zone,
       :name                      => 'KubernetesProvider',
       :connection_configurations => [{:endpoint       => {:role       => :default,
                                                           :hostname   => hostname,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_spec.rb
@@ -1,11 +1,10 @@
 describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::HawkularClient do
   before(:each) do
-    allow(MiqServer).to receive(:my_zone).and_return("default")
     hostname = 'hawkular.example.com'
     token = 'the_token'
 
     @ems = FactoryGirl.create(
-      :ems_kubernetes,
+      :ems_kubernetes_with_zone,
       :name                      => 'KubernetesProvider',
       :connection_configurations => [{:endpoint       => {:role     => :default,
                                                           :hostname => hostname,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_legacy_capture_context_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_legacy_capture_context_spec.rb
@@ -1,11 +1,10 @@
 describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::HawkularLegacyCaptureContext do
   before(:each) do
-    allow(MiqServer).to receive(:my_zone).and_return("default")
     hostname = 'capture.context.com'
     token = 'theToken'
 
     @ems = FactoryGirl.create(
-      :ems_kubernetes,
+      :ems_kubernetes_with_zone,
       :name                      => 'KubernetesProvider',
       :connection_configurations => [{:endpoint       => {:role       => :default,
                                                           :hostname   => hostname,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_spec.rb
@@ -3,14 +3,12 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Prom
     @record = :none
     # @record = :new_episodes
 
-    allow(MiqServer).to receive(:my_zone).and_return("default")
-
     master_hostname = 'master.example.com'
     hostname = 'prometheus.example.com'
     token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJtYW5hZ2VtZW50LWluZnJhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im1hbmFnZW1lbnQtYWRtaW4tdG9rZW4tZnJyeDgiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibWFuYWdlbWVudC1hZG1pbiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjRhODY5NDczLWQ1ZGQtMTFlNy1iNjhlLTAwMWE0YTE2MjZiZCIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDptYW5hZ2VtZW50LWluZnJhOm1hbmFnZW1lbnQtYWRtaW4ifQ.UhGy45pjWTak0NznD1v2rQtbf-XYis_5_ZKqVL0o7_4NFc69hsZZ4i_pSl2Pb4qsyNhWyZRY0JpKmBDz8CXIiZTb92laqrg_QQO4qMxo1nn2dHq_8nsMfdMAzR_dDzbUAlyPjhLMqUU9CecWzTodZ_PxLEfjZpMw8qIVAtca5fl5xgK1TbvnBdbnD_wK57PphadAZ1MCUdgzNgrs58WC59R1dv0lCL15UEXxamowLDZy1zWOG-WiHxFz5wN5iN7KCkPMnABOLoQ4k53kg-4sZzwqCPziUqyWm0mer2TwLzhqkuztzJnQ9AQBtt1kWvFKmPfGDUZ91bfGNfKeyd1gFw'
 
     @ems = FactoryGirl.create(
-      :ems_kubernetes,
+      :ems_kubernetes_with_zone,
       :name                      => 'KubernetesProvider',
       :connection_configurations => [{:endpoint       => {:role       => :default,
                                                           :hostname   => master_hostname,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_client_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_client_spec.rb
@@ -1,10 +1,9 @@
 describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::PrometheusClient do
   before(:each) do
-    allow(MiqServer).to receive(:my_zone).and_return("default")
     hostname = 'prometheus.example.com'
     token = 'good_token'
     @ems = FactoryGirl.create(
-      :ems_kubernetes,
+      :ems_kubernetes_with_zone,
       :name                      => 'KubernetesProvider',
       :connection_configurations => [{:endpoint       => {:role       => :default,
                                                           :hostname   => hostname,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/rollup_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/rollup_spec.rb
@@ -6,12 +6,11 @@ shared_examples "kubernetes rollup tests" do
   end
 
   let(:ems) do
-    allow(MiqServer).to receive(:my_zone).and_return("default")
     hostname = 'capture.context.com'
     token = 'theToken'
 
     @ems = FactoryGirl.create(
-      :ems_kubernetes,
+      :ems_kubernetes_with_zone,
       :name                      => 'KubernetesProvider',
       :connection_configurations => [{:endpoint       => {:role       => :default,
                                                           :hostname   => hostname,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -1,9 +1,8 @@
 # instantiated at the end, for both classical and graph refresh
 shared_examples "kubernetes refresher VCR tests" do
   before(:each) do
-    allow(MiqServer).to receive(:my_zone).and_return("default")
     auth = AuthToken.new(:name => "test", :auth_key => "valid-token")
-    @ems = FactoryGirl.create(:ems_kubernetes, :hostname => "10.35.0.169",
+    @ems = FactoryGirl.create(:ems_kubernetes_with_zone, :hostname => "10.35.0.169",
                               :ipaddress => "10.35.0.169", :port => 6443,
                               :authentications => [auth])
     # NOTE: the following :uid_ems should match (downcased) the kubernetes

--- a/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -1,13 +1,12 @@
 # instantiated at the end
 shared_examples "openshift refresher VCR targeted refresh tests" do
   before(:each) do
-    allow(MiqServer).to receive(:my_zone).and_return("default")
     hostname          = 'host.example.com'
     token             = 'theToken'
     hawkular_hostname = 'host.example.com'
 
     @ems = FactoryGirl.create(
-      :ems_kubernetes,
+      :ems_kubernetes_with_zone,
       :name                      => 'KubernetesProvider',
       :connection_configurations => [{:endpoint       => {:role       => :default,
                                                           :hostname   => hostname,

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -234,7 +234,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
 
     it "Deletes the monitoring manager when container manager is removed the prometheus_alerts endpoint" do
       ems = FactoryGirl.create(
-        :ems_kubernetes,
+        :ems_kubernetes_with_zone,
         :endpoints => [
           FactoryGirl.build(:endpoint, :role => 'default', :hostname => 'host2'),
           FactoryGirl.build(:endpoint, :role => 'prometheus_alerts', :hostname => 'host2')
@@ -243,7 +243,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       expect(ems.monitoring_manager).not_to be_nil
       expect(ems.monitoring_manager.parent_manager).to eq(ems)
 
-      allow(MiqServer).to receive(:my_zone).and_return("default")
       ems.endpoints = [FactoryGirl.build(:endpoint, :role => 'default', :hostname => 'host3')]
       queue_item = MiqQueue.find_by(:method_name => 'destroy')
       expect(queue_item).not_to be_nil
@@ -306,7 +305,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
 
     it "Deletes the virtualization manager when container manager is removed the kubevirt endpoint" do
       ems = FactoryGirl.create(
-        :ems_kubernetes,
+        :ems_kubernetes_with_zone,
         :endpoints => [
           FactoryGirl.build(:endpoint, :role => 'default', :hostname => 'host'),
           FactoryGirl.build(:endpoint, :role => 'kubevirt', :hostname => 'host')
@@ -315,7 +314,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       expect(ems.infra_manager).not_to be_nil
       expect(ems.infra_manager.parent_manager).to eq(ems)
 
-      allow(MiqServer).to receive(:my_zone).and_return("default")
       ems.endpoints = [FactoryGirl.build(:endpoint, :role => 'default', :hostname => 'host')]
       queue_item = MiqQueue.find_by(:method_name => 'destroy')
       expect(queue_item).not_to be_nil


### PR DESCRIPTION
Specs for metrics capture were failing due to a missing zone on the EMS