### PR TITLE
Travis - change postgresql to 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ env:
   - RUBY_GC_HEAP_INIT_SLOTS=600000
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'
 install: bin/setup
 after_script: bundle exec codeclimate-test-reporter


### PR DESCRIPTION
9.4 support dropped in https://github.com/ManageIQ/manageiq/pull/18090.
Should fix bin/setup failure (and possibly later problems): https://travis-ci.org/ManageIQ/manageiq-providers-kubernetes/jobs/442105217#L1939-L1980.

Matches core change https://github.com/ManageIQ/manageiq/pull/15994.

