### PR TITLE
Fix spec assuming default zone

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -153,7 +153,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       expect(job.target_class).to eq(image.class.name)
       expect(job.target_id).to eq(image.id)
       expect(job.type).to eq(ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job.name)
-      expect(job.zone).to eq("default")
+      expect(job.zone).to eq(@ems.zone.name)
       expect(job.userid).to eq("bob")
     end
   end


### PR DESCRIPTION
This container scan test was assuming the EMS was put in the default
zone when checking the zone name.