### PR TITLE
Different way to check for scan job's complete state.

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -261,7 +261,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def raise_image_scan_event(image)
-    suffix = state == 'finishing' ? 'complete' : 'abort'
+    suffix = %w(aborting canceling).include?(state) ? 'abort' : 'complete'
     MiqEvent.raise_evm_job_event(image, :type => "scan", :suffix => suffix)
   end
 


### PR DESCRIPTION
State finishing does not exist in hammer branch.

Followup of https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/303.

https://bugzilla.redhat.com/show_bug.cgi?id=1499161

@miq-bot add_label bug, hammer/yes

cc @gmcculloug