### PR TITLE
Refactor the event catcher filtered? method

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -75,10 +75,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
     end
 
     supported_reasons = ENABLED_EVENTS[event_data[:kind]] || []
-
-    unless supported_reasons.include?(event_data[:reason])
-      return
-    end
+    return unless supported_reasons.include?(event_data[:reason])
 
     event_type_prefix = event_data[:kind].upcase
 
@@ -105,6 +102,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
     end
 
     event_data[:event_type] = "#{event_type_prefix}_#{event_data[:reason].upcase}"
+    return if filtered_events.include?(event_data[:event_type])
 
     event_data
   end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -1,3 +1,4 @@
+require 'recursive-open-struct'
 describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
   let(:test_class) do
     Class.new do
@@ -263,6 +264,101 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           expect(test_class.new(ems).extract_event_data(missing_uid_event)).to eq(expected_data)
         end
       end
+    end
+    context 'given an event with an unsupported kind' do
+      let(:kubernetes_event) do
+        {
+          'reason'         => 'DoesItReallyMatter',
+          'involvedObject' => {
+            'kind' => 'SomeRandomObject',
+          },
+        }
+      end
+
+      it 'will return nil' do
+        event = RecursiveOpenStruct.new(:object => kubernetes_event)
+        expect(test_class.new.extract_event_data(event)).to be nil
+      end
+    end
+
+    context 'given an event with an unsupported reason' do
+      let(:kubernetes_event) do
+        {
+          'reason'         => 'DoesItReallyMatter',
+          'involvedObject' => {
+            'kind' => 'ReplicationController',
+          },
+        }
+      end
+
+      it 'will return nil' do
+        event = RecursiveOpenStruct.new(:object => kubernetes_event)
+        expect(test_class.new.extract_event_data(event)).to be nil
+      end
+    end
+  end
+
+  describe "#filtered?" do
+    let(:kubernetes_event) do
+      {
+        'metadata'       => {
+          'name'              => 'mysql-1.146486622e01d244',
+          'namespace'         => 'proj',
+          'selfLink'          => '/api/v1/namespaces/proj/events/mysql-1.146486622e01d244',
+          'uid'               => '4c513e6d-525d-11e6-8564-525400c7c086',
+          'resourceVersion'   => '1360577',
+          'creationTimestamp' => '2016-07-25T11:45:34Z',
+          'deletionTimestamp' => '2016-07-25T13:45:34Z'
+        },
+        'involvedObject' => {
+          'kind'            => 'ReplicationController',
+          'namespace'       => 'proj',
+          'name'            => 'mysql-1',
+          'uid'             => '7599d451-4c1c-11e6-89dd-525400c7c086',
+          'apiVersion'      => 'v1',
+          'resourceVersion' => '1360571'
+        },
+        'reason'         => 'SuccessfulCreate',
+        'message'        => 'Created pod: mysql-1-i4b54',
+        'source'         => {
+          'component' => 'replication-controller'
+        },
+        'firstTimestamp' => '2016-07-25T11:45:34Z',
+        'lastTimestamp'  => '2016-07-25T11:45:34Z',
+        'count'          => 1,
+        'type'           => 'Normal'
+      }
+    end
+
+    let(:event) { RecursiveOpenStruct.new(:object => kubernetes_event) }
+
+    let(:test_instance) do
+      test_class.new.tap do |i|
+        allow(i).to receive(:filtered_events).and_return([])
+      end
+    end
+
+    it 'with a blacklisted event' do
+      expect(test_instance).to receive(:filtered_events).and_return(["REPLICATOR_SUCCESSFULCREATE"])
+      expect(test_instance.filtered?(event)).to be_truthy
+    end
+
+    it 'with a non-blacklisted event' do
+      expect(test_instance.filtered?(event)).to be_falsey
+    end
+
+    it 'with an event with an unsupported kind' do
+      kubernetes_event.store_path('involvedObject', 'kind', 'SomeRandomObject')
+
+      event = RecursiveOpenStruct.new(:object => kubernetes_event)
+      expect(test_instance.filtered?(event)).to be_truthy
+    end
+
+    it 'with an event with an unsupported reason' do
+      kubernetes_event.store_path('reason', 'DoesItReallyMatter')
+
+      event = RecursiveOpenStruct.new(:object => kubernetes_event)
+      expect(test_instance.filtered?(event)).to be_truthy
     end
   end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -2,8 +2,10 @@ require 'recursive-open-struct'
 describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
   let(:test_class) do
     Class.new do
+      attr_reader :filtered_events
       def initialize(ems = nil)
         @ems = ems if ems
+        @filtered_events = []
       end
     end.include(described_class)
   end
@@ -272,6 +274,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           'involvedObject' => {
             'kind' => 'SomeRandomObject',
           },
+          'metadata'       => {
+            'uid' => 'SomeRandomUid',
+          },
         }
       end
 
@@ -287,6 +292,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           'reason'         => 'DoesItReallyMatter',
           'involvedObject' => {
             'kind' => 'ReplicationController',
+          },
+          'metadata'       => {
+            'uid' => 'SomeRandomUid',
           },
         }
       end
@@ -332,11 +340,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
 
     let(:event) { RecursiveOpenStruct.new(:object => kubernetes_event) }
 
-    let(:test_instance) do
-      test_class.new.tap do |i|
-        allow(i).to receive(:filtered_events).and_return([])
-      end
-    end
+    let(:test_instance) { test_class.new }
 
     it 'with a blacklisted event' do
       expect(test_instance).to receive(:filtered_events).and_return(["REPLICATOR_SUCCESSFULCREATE"])

--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -267,6 +267,11 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
         end
       end
     end
+  end
+
+  describe "#filtered?" do
+    let(:test_instance) { test_class.new }
+
     context 'given an event with an unsupported kind' do
       let(:kubernetes_event) do
         {
@@ -280,9 +285,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
         }
       end
 
-      it 'will return nil' do
+      it 'will return true' do
         event = RecursiveOpenStruct.new(:object => kubernetes_event)
-        expect(test_class.new.extract_event_data(event)).to be nil
+        expect(test_instance.filtered?(event)).to be_truthy
       end
     end
 
@@ -299,14 +304,12 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
         }
       end
 
-      it 'will return nil' do
+      it 'will return true' do
         event = RecursiveOpenStruct.new(:object => kubernetes_event)
-        expect(test_class.new.extract_event_data(event)).to be nil
+        expect(test_instance.filtered?(event)).to be_truthy
       end
     end
-  end
 
-  describe "#filtered?" do
     let(:kubernetes_event) do
       {
         'metadata'       => {
@@ -339,8 +342,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
     end
 
     let(:event) { RecursiveOpenStruct.new(:object => kubernetes_event) }
-
-    let(:test_instance) { test_class.new }
 
     it 'with a blacklisted event' do
       expect(test_instance).to receive(:filtered_events).and_return(["REPLICATOR_SUCCESSFULCREATE"])


### PR DESCRIPTION
The base_manager event_catcher maintains a list of filtered events from the ems event type blacklist. This list should be checked when checking if an event is to be filtered or not.
\+ Combine all of the filtered logic into the filtered? method and extract it from extract_event_data.

Based on ManageIQ/manageiq#14632

~~Depends on: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/308~~

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653871