### PR TITLE
[GAPRINDASHVILI] use memory working_set in legacy collector

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -81,5 +81,6 @@
             :prometheus_open_timeout: 5
             :prometheus_request_timeout: 30
             :hawkular_force_legacy: true
+            :legacy_use_working_set: false
         :ems_refresh_worker:
           :ems_refresh_worker_kubernetes: {}


### PR DESCRIPTION
**Description**
Add an option to use `memory/working_set` metrics with legacy metrics collector.

In https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/306 [1] we only replaced `memory/usage` with `memory/working_set` for the new collector, leaving the legacy collector unchanged.

The `memory/working-set` was intruduced in heapster v1.1 [2] used in origin metrics v1.3 [3], and can be used safely with legacy openshift/hawkular (pre 3.7).

This PR adds the option to use the legacy collector using `memory/working_set`.
It adds an option to enable/disable this option to make is possible for users that do not have the new `memory/working_set` or want to leave the current metric unchanged to chose witch metrics to sue.

Options is set to `false` not to force the change on old systems.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1654463

[1] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/306
[2] https://github.com/kubernetes-retired/heapster/commit/3ca8b4fb0b7d469e5334772e6b4a736834bce03c
[3] https://github.com/openshift/origin-metrics/commit/e4837dfb85f98f17c908aae8511f2527a3be7813


