### PR TITLE
MonitoringManager spec: update to explicitly start from unvalidated auth

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/monitoring_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/monitoring_manager_spec.rb
@@ -1,17 +1,19 @@
 describe ManageIQ::Providers::Kubernetes::MonitoringManager do
   let(:default_endpoint) { FactoryGirl.create(:endpoint, :role => 'default', :hostname => 'host') }
-  let(:default_authentication) { FactoryGirl.create(:authentication, :authtype => 'bearer') }
+  let(:default_authentication) { FactoryGirl.create(:authentication, :authtype => 'bearer', :status => nil) }
   let(:prometheus_authentication) do
     FactoryGirl.create(
       :authentication,
       :authtype => 'prometheus_alerts',
       :auth_key => '_',
+      :status => nil,
     )
   end
 
   let(:container_manager) do
     FactoryGirl.create(
       :ems_kubernetes,
+      :with_unvalidated_authentication,
       :endpoints       => [
         default_endpoint,
         prometheus_alerts_endpoint,


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/18266 changed factories by default to create "Valid" auth, requiring explicit opt-out for test scenarios like here unvalidated->`check_types`->expected status.

Fixes red travis: https://travis-ci.org/ManageIQ/manageiq-providers-kubernetes/jobs/474807718#L2098
(tracking issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/4921#issuecomment-451129620)

@kbrock @bdunne please review