### PR TITLE
Call .create_job from the Scanning class

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -228,8 +228,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
   def raw_scan_job_create(target_class, target_id = nil, userid = nil, target_name = nil)
     raise MiqException::Error, _("target_class must be a class not an instance") if target_class.kind_of?(ContainerImage)
-    Job.create_job(
-      "ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job",
+    ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job.create_job(
       :userid          => userid,
       :name            => "Container Image Analysis: '#{target_name}'",
       :target_class    => target_class,


### PR DESCRIPTION
Instead of calling Job.create_job and passing the scanning job class
name we can call create_job from the final class not the base class.
This opens up future refactorings for the base create_job class.