### PR TITLE
update_attributes deprecation

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -102,7 +102,7 @@ module ManageIQ::Providers
         raise TargetValidationWarning, "no metrics endpoint found for #{target_name}" if context.nil?
       rescue TargetValidationError, TargetValidationWarning => e
         _log.send(e.log_severity, "[#{target_name}] #{e.message}")
-        ems.try(:update_attributes,
+        ems.try(:update,
                 :last_metrics_error       => :invalid,
                 :last_metrics_update_date => Time.now.utc)
         raise
@@ -115,13 +115,13 @@ module ManageIQ::Providers
           _log.warn("Metrics missing: [#{target_name}] #{e.message}")
         rescue StandardError => e
           _log.error("Metrics unavailable: [#{target_name}] #{e.message}")
-          ems.update_attributes(:last_metrics_error       => :unavailable,
+          ems.update(:last_metrics_error       => :unavailable,
                                 :last_metrics_update_date => Time.now.utc) if ems
           raise
         end
       end
 
-      ems.update_attributes(:last_metrics_error        => nil,
+      ems.update(:last_metrics_error        => nil,
                             :last_metrics_update_date  => Time.now.utc,
                             :last_metrics_success_date => Time.now.utc) if ems
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/rollup_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/rollup_spec.rb
@@ -40,7 +40,7 @@ shared_examples "kubernetes rollup tests" do
 
     node = FactoryBot.create(:container_node)
 
-    hardware.update_attributes(:computer_system => node.computer_system)
+    hardware.update(:computer_system => node.computer_system)
     node
   end
 
@@ -51,7 +51,7 @@ shared_examples "kubernetes rollup tests" do
 
     node = FactoryBot.create(:container_node)
 
-    hardware.update_attributes(:computer_system => node.computer_system)
+    hardware.update(:computer_system => node.computer_system)
     node
   end
 


### PR DESCRIPTION
update_attributes and update_attributes! are deprecated starting in Rails 6

See https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/ for details and Rails PR links.