### PR TITLE
Remove zanata.xml

### DIFF
--- a/zanata.xml
+++ b/zanata.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<config xmlns="http://zanata.org/namespace/config/">
-  <url>https://translate.zanata.org/</url>
-  <project>manageiq-providers-kubernetes</project>
-  <project-version>master</project-version>
-  <project-type>gettext</project-type>
-</config>


### PR DESCRIPTION
We no longer do per-plugin translations, zanata config file is no longer needed.

@miq-bot add_label cleanup