### PR TITLE
Fix scanning pod fake "hostname" for long image names

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -419,8 +419,12 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
         }
       },
       :spec       => {
-        # determines the 'target name' in the report
-        :hostname      => options[:image_name].match(/(?:.*\/)*(.*)$/).captures[0].downcase.tr("._-", "").truncate(63),
+        # A hack to smuggle at least partial info which image was scanned into the
+        # OpenSCAP report - determines the "target name" in the report.
+        # Must be lowercase and valid DNS RFC-1123 label up to 63 chars or kubernetes
+        # won't run the pod.
+        :hostname      => options[:image_name].match(/(?:.*\/)*(.*)$/).captures[0]
+                                              .downcase.tr("^a-z0-9", "").truncate(63, :omission => ""),
         :restartPolicy => 'Never',
         :containers    => [
           {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1751267

Setting "hostname" was an enhancement in https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/248 to improve image names but it introduced a regression:

Pod spec could be invalid for long image names, causing scanning to not run at all.
(Possibly also for weird characters in name, not sure if realistic but made code more robust to that too.)

----

#### historical references that were too verbose for comments, not really interesting:

Expanded comments to clarify lowercase requirement is by Kubernetes not the DNS RFC (https://github.com/kubernetes/kubernetes/pull/39675).
The RFC also says:

> Host software MUST handle host names of up to 63 characters and SHOULD handle host names of up to 255 characters

so a bit ambiguous what's "valid DNS label" means but anyway Kubernetes enforces 63 (some history on https://github.com/kubernetes/kubernetes/issues/4825)
