### PR TITLE
Fix parsing capacity fields of the form 50M or 1G

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -875,7 +875,7 @@ module ManageIQ::Providers::Kubernetes
     def parse_capacity_field(key, val)
       return nil unless val
       begin
-        val.iec_60027_2_to_i
+        parse_quantity(val)
       rescue ArgumentError
         _log.warn("Capacity attribute - #{key} was in bad format - #{val}")
         nil


### PR DESCRIPTION
If the storage capacity attribute is of the form 50M or 1G the
parse_capacity_field method which only expects IEC 60027-2 style values
will fail:

```
MIQ(ManageIQ::Providers::Openshift::ContainerManager::RefreshParser#parse_capacity_field) Capacity attribute - storage was in bad format - 1G
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1782902