### PR TITLE
Subclass ContainerManager metrics capture

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -1,5 +1,5 @@
 module ManageIQ::Providers
-  class Kubernetes::ContainerManager::MetricsCapture < BaseManager::MetricsCapture
+  class Kubernetes::ContainerManager::MetricsCapture < ContainerManager::MetricsCapture
     class CollectionFailure < RuntimeError; end
     class NoMetricsFoundError < RuntimeError; end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -70,6 +70,12 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
     )
   end
 
+  context "#perf_capture_object" do
+    it "returns the correct class" do
+      expect(@ems_kubernetes.perf_capture_object.class).to eq(described_class)
+    end
+  end
+
   context "#capture_context" do
     it "detect prometheus metrics provider" do
       metric_capture = described_class.new(@node_prometheus)


### PR DESCRIPTION
kubernetes is a container metrics capture class. subclassing the proper parent

part of ManageIQ/manageiq#19684