### PR TITLE
Lazy load kubeclient/image inspector library with autoload

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/container_template_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_template_mixin.rb
@@ -1,3 +1,5 @@
+autoload(:KubeException, 'kubeclient')
+
 module ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplateMixin
   extend ActiveSupport::Concern
   include ManageIQ::Providers::Kubernetes::ContainerManager::EntitiesMapping

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
@@ -1,3 +1,5 @@
+autoload(:KubeException, 'kubeclient')
+
 module ManageIQ
   module Providers
     module Kubernetes

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -1,5 +1,6 @@
-require 'image-inspector-client'
-require 'kubeclient'
+autoload(:ImageInspectorClient, 'image-inspector-client')
+autoload(:Kubeclient, 'kubeclient')
+autoload(:KubeException, 'kubeclient')
 
 class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   PROVIDER_CLASS = ManageIQ::Providers::Kubernetes::ContainerManager

--- a/app/models/manageiq/providers/kubernetes/container_manager/streaming_refresh_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/streaming_refresh_mixin.rb
@@ -1,3 +1,5 @@
+autoload(:KubeException, 'kubeclient')
+
 module ManageIQ::Providers::Kubernetes::ContainerManager::StreamingRefreshMixin
   include Vmdb::Logging
 

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
@@ -1,3 +1,5 @@
+autoload(:KubeException, 'kubeclient')
+
 class ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector
   # TODO(lsmola) we need to return iterator for each collection, so we avoid fetching too many items to memory at
   # once.

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_mixin_spec.rb
@@ -1,5 +1,3 @@
-require 'kubeclient'
-
 describe ManageIQ::Providers::Kubernetes::ContainerManager::RefresherMixin do
   let(:client)  { double("client") }
   let(:ems)     { FactoryBot.create(:ems_kubernetes) }


### PR DESCRIPTION
Note, there doesn't seem to be one single entrypoint for these classes and
mixins so when possible, we now autoload any constants being used in these
files.

Note, it's best to require or use ruby's autoload on libraries like this.
Normal rails models and other files that need to be reloaded by rails in dev
mode need to be loaded by using the constant directly to force const_missing
or use require_dependency.