### PR TITLE
Fix warning and strict partial failure

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -2,10 +2,15 @@ require 'recursive-open-struct'
 describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
   let(:test_class) do
     Class.new do
+      include Vmdb::Logging
       attr_reader :filtered_events
       def initialize(ems = nil)
         @ems = ems if ems
         @filtered_events = []
+      end
+
+      def log_prefix
+        # Interface stub
       end
     end.include(described_class)
   end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -133,6 +133,8 @@ class MockFailedImageInspectorClient < MockImageInspectorClient
 end
 
 describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
+  let(:img_acq_err) { "can't find image" }
+
   context "SmartState Analysis Methods" do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -521,7 +523,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
 
     context 'fetch_metadata fails to access pod' do
       it 'reports failure when fetch_metadata fails to access pod' do
-        IMG_ACQ_ERR = "can't find image".freeze
         allow_any_instance_of(described_class).to receive_messages(
           :image_inspector_client => MockCantAccessImageInspectorClient.new
         )
@@ -535,15 +536,14 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
 
     context 'Image Acquiring Status' do
       it 'Detects when image acquiring failed and reports the error' do
-        IMG_ACQ_ERR = "can't find image".freeze
         allow_any_instance_of(described_class).to receive_messages(
-          :image_inspector_client => MockFailedImageInspectorClient.new("Sucess", "", IMG_ACQ_ERR, IMAGE_ID)
+          :image_inspector_client => MockFailedImageInspectorClient.new("Sucess", "", img_acq_err, IMAGE_ID)
         )
         expect(MiqEvent).to receive(:raise_evm_job_event).with(@image, :type => "scan", :suffix => "abort")
         @job.signal(:start)
         expect(@job.state).to eq 'finished'
         expect(@job.status).to eq 'error'
-        expect(@job.message).to eq "image acquiring error: #{IMG_ACQ_ERR}"
+        expect(@job.message).to eq "image acquiring error: #{img_acq_err}"
       end
     end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -133,8 +133,6 @@ class MockFailedImageInspectorClient < MockImageInspectorClient
 end
 
 describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
-  let(:img_acq_err) { "can't find image" }
-
   context "SmartState Analysis Methods" do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -537,13 +535,13 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
     context 'Image Acquiring Status' do
       it 'Detects when image acquiring failed and reports the error' do
         allow_any_instance_of(described_class).to receive_messages(
-          :image_inspector_client => MockFailedImageInspectorClient.new("Sucess", "", img_acq_err, IMAGE_ID)
+          :image_inspector_client => MockFailedImageInspectorClient.new("Success", "", "can't find image", IMAGE_ID)
         )
         expect(MiqEvent).to receive(:raise_evm_job_event).with(@image, :type => "scan", :suffix => "abort")
         @job.signal(:start)
         expect(@job.state).to eq 'finished'
         expect(@job.status).to eq 'error'
-        expect(@job.message).to eq "image acquiring error: #{img_acq_err}"
+        expect(@job.message).to eq "image acquiring error: can't find image"
       end
     end
 


### PR DESCRIPTION
Refactoring PR that eliminates a constant redefinition warning. It also implements previously undefined methods either by including the `Vmdb::Logging` module (for the `_log` method) or by defining it directly (the `log_prefix` method). Without these, the specs fail with strict partial validation turned on.

There are other constants that should probably be replaced with `let` but this PR just focuses on fixes for now.