### PR TITLE
Use an inventory_collection to raise created events

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
@@ -78,28 +78,6 @@ module ManageIQ
             end
           end
         end
-
-        def manager_refresh_post_processing(_ems, _target, persister)
-          raise_creation_events(persister.container_images)
-          raise_creation_events(persister.container_projects)
-        end
-
-        def raise_creation_events(saved_collection)
-          # We want this post processing job only for batches, for the rest it's after_create hook on the Model
-          return unless saved_collection.saver_strategy == :batch
-
-          # TODO extract the batch size to Settings
-          batch_size = 100
-          saved_collection.created_records.each_slice(batch_size) do |batch|
-            collection_ids = batch.collect { |x| x[:id] }
-            MiqQueue.submit_job(
-              :class_name  => saved_collection.model_class.to_s,
-              :method_name => 'raise_creation_events',
-              :args        => [collection_ids],
-              :priority    => MiqQueue::HIGH_PRIORITY
-            )
-          end
-        end
       end
     end
   end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/definitions/container_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/definitions/container_collections.rb
@@ -9,11 +9,13 @@ module ManageIQ::Providers::Kubernetes::Inventory::Persister::Definitions::Conta
        container_groups
        container_image_registries
        container_images
+       container_images_creation_events
        container_limits
        container_limit_items
        container_nodes
        container_port_configs
        container_projects
+       container_project_creation_events
        container_quotas
        container_quota_scopes
        container_quota_items


### PR DESCRIPTION
Instead of an extra method in the Refresher class we can raise creation
events with an inventory_collection which is more consistent with how
this is typically done and we can clean up the base Refresher class.

Containers were the only providers that actually used this
manager_refresh_post_processing method and it can be deleted now.

Depends on: ~~https://github.com/ManageIQ/manageiq/pull/19973~~