### PR TITLE
Use be_within to fix rollup_spec sporadic failure

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/rollup_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/rollup_spec.rb
@@ -211,7 +211,7 @@ shared_examples "kubernetes rollup tests" do
         :derived_memory_used        => 2048.0,
         :derived_vm_numvcpus        => 12.0,
         :derived_memory_available   => 3072.0,
-        :mem_usage_absolute_average => 66.6666666666667
+        :mem_usage_absolute_average => be_within(0.001).of(66.666)
       )
     )
 


### PR DESCRIPTION
Depending on the floating point precision the rollup spec would
sometimes fail to match:
```
  1) ManageIQ::Providers::Kubernetes::ContainerManager::Refresher check project rollup can handle partial hour
     Failure/Error:
       expect(project_rollup).to(
         have_attributes(
           :derived_memory_used        => 2048.0,
           :derived_vm_numvcpus        => 12.0,
           :derived_memory_available   => 3072.0,
           :mem_usage_absolute_average => 66.6666666666667
         )
       )
     
       expected #<MetricRollup id: 25000000000170, timestamp: "2012-09-01 00:00:00", capture_interval: nil, resource_...up_create_rate: 0, stat_container_group_delete_rate: 0, stat_container_image_registration_rate: nil> to have attributes {:derived_memory_available => 3072.0, :derived_memory_used => 2048.0, :derived_vm_numvcpus => 12.0, :mem_usage_absolute_average => 66.6666666666667} but had attributes {:derived_memory_available => 3072.0, :derived_memory_used => 2048.0, :derived_vm_numvcpus => 12.0, :mem_usage_absolute_average => 66.66666666666667}
       Diff:
       @@ -1,5 +1,5 @@
        :derived_memory_available => 3072.0,
        :derived_memory_used => 2048.0,
        :derived_vm_numvcpus => 12.0,
       -:mem_usage_absolute_average => 66.6666666666667,
       +:mem_usage_absolute_average => 66.66666666666667,
```