### PR TITLE
Use watches for targeted refresh

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker.rb
@@ -1,3 +1,4 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
   require_nested :Runner
+  require_nested :WatchThread
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
@@ -121,7 +121,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner <
   end
 
   def refresher
-    _log.debug("Starting refresher thread")
+    _log.debug("#{log_header} Starting refresher thread")
 
     loop do
       notices = []
@@ -135,10 +135,15 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner <
       notices << queue.pop until queue.empty? || notices.count > refresh_notice_threshold
       notices.compact!
 
+      _log.debug { "#{log_header} Refreshing #{notices.count} total notices" }
+      notices_by_kind = notices.group_by { |notice| notice.object.kind }
+      notices_by_kind.each do |kind, notices|
+        _log.debug { "#{log_header}   #{kind}: #{notices.count} notices" }
+      end
       partial_refresh(notices)
     end
 
-    _log.debug("Exiting refresher thread")
+    _log.debug { "#{log_header} Exiting refresher thread" }
   end
 
   def ensure_collector_threads

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
@@ -137,8 +137,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner <
 
       _log.debug { "#{log_header} Refreshing #{notices.count} total notices" }
       notices_by_kind = notices.group_by { |notice| notice.object.kind }
-      notices_by_kind.each do |kind, notices|
-        _log.debug { "#{log_header}   #{kind}: #{notices.count} notices" }
+      notices_by_kind.each do |kind, n|
+        _log.debug { "#{log_header}   #{kind}: #{n.count} notices" }
       end
       partial_refresh(notices)
     end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
@@ -33,8 +33,12 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner <
   attr_accessor :collector_threads, :refresher_thread
   attr_reader   :ems, :finish, :queue, :refresh_notice_threshold, :resource_version_by_entity
 
-  def entity_types
+  def kubernetes_entity_types
     %w[pods replication_controllers nodes namespaces resource_quotas limit_ranges persistent_volumes persistent_volume_claims].freeze
+  end
+
+  def entity_types
+    kubernetes_entity_types
   end
 
   def refresh_block
@@ -113,7 +117,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner <
   end
 
   def start_collector_thread(entity_type)
-    ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::WatchThread.start!(ems, queue, entity_type, resource_version_by_entity[entity_type])
+    ems.class::RefreshWorker::WatchThread.start!(ems, queue, entity_type, resource_version_by_entity[entity_type])
   end
 
   def stop_collector_threads

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
@@ -34,7 +34,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner <
   attr_reader   :ems, :finish, :queue, :refresh_notice_threshold, :resource_version_by_entity
 
   def entity_types
-    %w[pods services endpoints replication_controllers nodes namespaces resource_quotas limit_ranges persistent_volumes persistent_volume_claims].freeze
+    %w[pods replication_controllers nodes namespaces resource_quotas limit_ranges persistent_volumes persistent_volume_claims].freeze
   end
 
   def refresh_block

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
@@ -1,2 +1,148 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner < ManageIQ::Providers::BaseManager::RefreshWorker::Runner
+  def after_initialize
+    super
+
+    @ems       = ExtManagementSystem.find(@cfg[:ems_id])
+    @ems_class = @ems.class
+    @finish    = Concurrent::AtomicBoolean.new
+    @queue     = Queue.new
+
+    @connect_options            = @ems.connect_options
+    @refresher_thread           = nil
+    @refresh_notice_threshold   = 100
+    @collector_threads          = Concurrent::Map.new
+    @resource_version_by_entity = Concurrent::Map.new
+    @watches_by_entity          = Concurrent::Map.new
+  end
+
+  def do_before_work_loop
+    # Prime the entities' resourceVersions by performing an initial full refresh
+    full_refresh
+  end
+
+  def do_work
+    ensure_refresher_thread
+    ensure_collector_threads
+  end
+
+  def before_exit(_message, _exit_code)
+    finish.make_true
+    stop_collector_threads
+    stop_refresher_thread
+  end
+
+  private
+
+  attr_accessor :collector_threads, :refresher_thread
+  attr_reader   :connect_options, :ems, :ems_class, :finish, :queue, :refresh_notice_threshold,
+                :resource_version_by_entity, :watches_by_entity
+
+  def entity_types
+    %w[pods services endpoints replication_controllers nodes namespaces resource_quotas limit_ranges persistent_volumes persistent_volume_claims].freeze
+  end
+
+  def refresh_block
+    yield
+
+    ems.update!(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
+  rescue => err
+    _log.error("#{log_header} Refresh failed: #{err}")
+    _log.log_backtrace(err)
+    ems.update!(:last_refresh_error => err.to_s, :last_refresh_date => Time.now.utc)
+  end
+
+  def save_resource_versions(collector)
+    entity_types.each { |entity| resource_version_by_entity[entity] = collector.send(entity).resourceVersion }
+  end
+
+  def full_refresh
+    refresh_block do
+      inventory = inventory_klass.build(ems, nil)
+      inventory.parse&.persist!
+
+      save_resource_versions(inventory.collector)
+    end
+  end
+
+  def partial_refresh(notices)
+    refresh_block do
+    end
+  end
+
+  def ensure_refresher_thread
+    self.refresher_thread = start_refresher_thread unless refresher_thread&.alive?
+  end
+
+  def start_refresher_thread
+    Thread.new { refresher }
+  end
+
+  def stop_refresher_thread
+    queue.push(nil) # Push a nil to unblock the refresher thread
+    refresher_thread.join(10)
+  end
+
+  def refresher
+    loop do
+      notices = []
+
+      # Use queue.pop to block until an item is in the queue
+      notices << queue.pop
+
+      break if finish.true?
+
+      # Then continue to pop without blocking until the queue is empty
+      notices << queue.pop until queue.empty? || notices.count > refresh_notice_threshold
+      notices.compact!
+
+      partial_refresh(notices)
+    end
+  end
+
+  def ensure_collector_threads
+    entity_types.each do |entity_type|
+      next if collector_threads[entity_type]&.alive?
+      collector_threads[entity_type] = start_collector_thread(entity_type)
+    end
+  end
+
+  def start_collector_thread(entity_type)
+    Thread.new { collector_thread(entity_type) }
+  end
+
+  def stop_collector_threads
+    entity_types.each { |entity_type| stop_collector_thread(entity_type) }
+  end
+
+  def stop_collector_thread(entity_type)
+    thread = collector_threads[entity_type]
+    return unless thread&.alive?
+
+    watches_by_entity[entity_type]&.finish
+    thread.join(10)
+  end
+
+  def collector_thread(entity_type)
+    resource_version = resource_version_by_entity[entity_type]
+    watches_by_entity[entity_type] = watch = connection.send("watch_#{entity_type}", :resource_version => resource_version)
+
+    until finish.true?
+      watch.each { |notice| queue.push(notice) }
+    end
+  end
+
+  def connection(_entity_type = nil)
+    hostname, port = connect_options.values_at(:hostname, :port)
+    connect_options[:service] ||= "kubernetes"
+
+    ems_class.raw_connect(hostname, port, connect_options)
+  end
+
+  def inventory_klass
+    @inventory_klass ||= "#{ManageIQ::Providers::Inflector.provider_module(ems.class)}::Inventory".constantize
+  end
+
+  def log_header
+    @log_header ||= "EMS [#{ems.name}], id: [#{ems.id}]"
+  end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
@@ -38,7 +38,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::WatchThr
 
   def collector_thread
     until finish.true?
-      self.watch ||= connection.send("watch_#{entity_type}", :resource_version => resource_version)
+      self.watch ||= connection(entity_type).send("watch_#{entity_type}", :resource_version => resource_version)
 
       watch.each do |notice|
         # If we get a 410 gone with this resource version break out and restart

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
@@ -37,7 +37,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::WatchThr
   attr_accessor :resource_version, :thread, :watch
 
   def collector_thread
-    _log.debug("Starting watch thread for #{entity_type}")
+    _log.debug { "Starting watch thread for #{entity_type}" }
 
     until finish.true?
       self.watch ||= connection(entity_type).send("watch_#{entity_type}", :resource_version => resource_version)
@@ -59,7 +59,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::WatchThr
       self.resource_version = nil
     end
 
-    _log.debug("Exiting watch thread #{entity_type}")
+    _log.debug { "Exiting watch thread #{entity_type}" }
   rescue => err
     _log.error("Watch thread for #{entity_type} failed: #{err}")
     _log.log_backtrace(err)

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
@@ -1,0 +1,67 @@
+class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::WatchThread
+  include Vmdb::Logging
+
+  def self.start!(ems, queue, entity_type, resource_version)
+    new(ems.connect_options, ems.class, queue, entity_type, resource_version).tap(&:start!)
+  end
+
+  def initialize(connect_options, ems_klass, queue, entity_type, resource_version)
+    @connect_options = connect_options
+    @ems_klass       = ems_klass
+    @entity_type     = entity_type
+    @finish          = Concurrent::AtomicBoolean.new
+    @queue           = queue
+
+    self.resource_version = resource_version
+  end
+
+  def alive?
+    thread&.alive?
+  end
+
+  def start!
+    self.thread = Thread.new { collector_thread }
+  end
+
+  def stop!(join_limit = 10.seconds)
+    return unless alive?
+
+    finish.make_true
+    watch&.finish
+    thread&.join(join_limit)
+  end
+
+  private
+
+  attr_reader :connect_options, :ems_klass, :entity_type, :finish, :queue
+  attr_accessor :resource_version, :thread, :watch
+
+  def collector_thread
+    until finish.true?
+      self.watch ||= connection.send("watch_#{entity_type}", :resource_version => resource_version)
+
+      watch.each do |notice|
+        # If we get a 410 gone with this resource version break out and restart
+        # the watch
+        break if notice.kind == "Status" && notice.code == 410
+
+        queue.push(notice)
+      end
+
+      # If the watch terminated for any reason (410 Gone or just interrupted) then
+      # restart with a resourceVersion of nil to start over from the current state
+      self.watch = nil
+      self.resource_version = nil
+    end
+  rescue => err
+    _log.error("Watch thread for #{entity_type} failed: #{err}")
+    _log.log_backtrace(err)
+  end
+
+  def connection(_entity_type = nil)
+    hostname, port = connect_options.values_at(:hostname, :port)
+    connect_options[:service] ||= "kubernetes"
+
+    ems_klass.raw_connect(hostname, port, connect_options)
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector.rb
@@ -1,3 +1,4 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   require_nested :ContainerManager
+  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
@@ -62,17 +62,22 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager < 
   def fetch_entity(client, entity)
     meth = "get_#{entity}"
 
-    continue = nil
+    continue = resource_version = kind = nil
     results = []
 
     loop do
       result = client.send(meth, :limit => refresher_options.chunk_size, :continue => continue)
+      break if result.nil?
+
+      kind = result.kind
+      resource_version = result.resourceVersion
+
       results += result
       break if result.last?
 
       continue = result.continue
     end
 
-    results
+    Kubeclient::Common::EntityList.new(kind, resource_version, results)
   end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/watch_notice.rb
@@ -1,10 +1,13 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Collector
   attr_reader :additional_attributes, :pods, :services, :endpoints, :replication_controllers,
-              :nodes, :namespaces, :resource_quotas, :limit_ranges, :persistent_volumes, :persistent_volume_claims
+              :namespaces, :nodes, :notices, :resource_quotas, :limit_ranges,
+              :persistent_volumes, :persistent_volume_claims
 
   def initialize(manager, notices)
+    @notices = filter_notices(notices)
+
     initialize_collections!
-    parse_notices!(notices)
+    populate_collections!
 
     super(manager, nil)
   end
@@ -12,28 +15,37 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice < Manag
   private
 
   def initialize_collections!
-    @additional_attributes = {}
-    @pods = []
-    @services = []
-    @endpoints = []
-    @replication_controllers = []
-    @nodes = []
-    @namespaces = []
-    @resource_quotas = []
-    @limit_ranges = []
-    @persistent_volumes = []
+    @additional_attributes    = {}
+    @pods                     = []
+    @services                 = []
+    @endpoints                = []
+    @replication_controllers  = []
+    @nodes                    = []
+    @namespaces               = []
+    @resource_quotas          = []
+    @limit_ranges             = []
+    @persistent_volumes       = []
     @persistent_volume_claims = []
   end
 
-  def parse_notices!(all_notices)
+  # The notices returned by the Kubernetes API contain always the complete
+  # representation of the object, so it isn't necessary to process all of them,
+  # only the last one for each object.
+  def filter_notices(all_notices)
     notices_by_kind = all_notices.group_by { |notice| notice.object&.kind }.except(nil)
-    notices_by_kind.each do |kind, notices|
-      # The notices returned by the Kubernetes API contain always the complete representation of the object, so it isn't
-      # necessary to process all of them, only the last one for each object.
-      notices.reverse!.uniq! { |n| n.object&.metadata&.uid }
 
-      # Only add ADDED/MODIFIED to the collectors so deleted objects will be removed
-      instance_variable_get("@#{kind.tableize}")&.concat(notices)
+    notices_by_kind.values.each_with_object([]) do |notices, result|
+      notices.reverse!.uniq! { |n| n.object&.metadata&.uid }
+      result.concat(notices)
+    end
+  end
+
+  # Pull the object out of the notices and populate the normal collections
+  # so that the Parser::ContainerManager can be used normally
+  def populate_collections!
+    # Only add ADDED/MODIFIED to the collectors so deleted objects will be removed
+    notices.reject { |n| n.type == "DELETED" }.each do |notice|
+      instance_variable_get("@#{notice.object.kind.tableize}") << notice.object
     end
   end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/watch_notice.rb
@@ -1,0 +1,39 @@
+class ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Collector
+  attr_reader :additional_attributes, :pods, :services, :endpoints, :replication_controllers,
+              :nodes, :namespaces, :resource_quotas, :limit_ranges, :persistent_volumes, :persistent_volume_claims
+
+  def initialize(manager, notices)
+    initialize_collections!
+    parse_notices!(notices)
+
+    super(manager, nil)
+  end
+
+  private
+
+  def initialize_collections!
+    @additional_attributes = {}
+    @pods = []
+    @services = []
+    @endpoints = []
+    @replication_controllers = []
+    @nodes = []
+    @namespaces = []
+    @resource_quotas = []
+    @limit_ranges = []
+    @persistent_volumes = []
+    @persistent_volume_claims = []
+  end
+
+  def parse_notices!(all_notices)
+    notices_by_kind = all_notices.group_by { |notice| notice.object&.kind }.except(nil)
+    notices_by_kind.each do |kind, notices|
+      # The notices returned by the Kubernetes API contain always the complete representation of the object, so it isn't
+      # necessary to process all of them, only the last one for each object.
+      notices.reverse!.uniq! { |n| n.object&.metadata&.uid }
+
+      # Only add ADDED/MODIFIED to the collectors so deleted objects will be removed
+      instance_variable_get("@#{kind.tableize}")&.concat(notices)
+    end
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   require_nested :ContainerManager
+  require_nested :WatchNotice
 
   def refresher_options
     Settings.ems_refresh[persister.manager.class.ems_type]

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -408,12 +408,14 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
 
   def node_computer_system_hardware(parent, hash)
     return if hash.nil?
+
     hash[:computer_system] = parent
     persister.computer_system_hardwares.build(hash)
   end
 
   def node_computer_system_operating_system(parent, hash)
     return if hash.nil?
+
     hash[:computer_system] = parent
     persister.computer_system_operating_systems.build(hash)
   end
@@ -462,7 +464,7 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
 
     new_result[:container_build_pod] = lazy_find_build_pod(
       :namespace => new_result[:namespace],
-      :name => pod.metadata.try(:annotations).try("openshift.io/build.name".to_sym)
+      :name      => pod.metadata.try(:annotations).try("openshift.io/build.name".to_sym)
     )
 
     # TODO, map volumes
@@ -733,8 +735,8 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
 
     # TODO: parse template
     new_result.merge!(
-      :replicas         => container_replicator.spec.replicas,
-      :current_replicas => container_replicator.status.replicas,
+      :replicas          => container_replicator.spec.replicas,
+      :current_replicas  => container_replicator.status.replicas,
       :container_project => lazy_find_project(:name => new_result[:namespace]),
     )
 

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -29,7 +29,7 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     persistent_volume_claims
     persistent_volumes
     pods
-    endpoints_and_services
+    services
   end
 
   def additional_attributes
@@ -145,52 +145,28 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     end
   end
 
+  def cgs_by_namespace_and_name
+    @cgs_by_namespace_and_name ||= begin
+      # We don't save endpoints themselves, only parse for cross-linking services<->pods
+      collector.endpoints.each_with_object({}) do |endpoint, result|
+        ep = parse_endpoint(endpoint)
+
+        container_groups = []
+        ep.delete(:container_groups_refs).each do |ref|
+          next if ref.nil?
+          cg = lazy_find_container_group(:namespace => ref[:namespace], :name => ref[:name])
+          container_groups << cg unless cg.nil?
+        end
+        result.store_path(ep[:namespace], ep[:name], container_groups)
+      end
+    end
+  end
+
   # TODO: how would this work with partial refresh?
   # TODO: can I write get_endpoints() that directly refreshes ContainerGroupsContainerServices join table?
-  def endpoints_and_services
-    cgs_by_namespace_and_name = {}
-
-    # We don't save endpoints themselves, only parse for cross-linking services<->pods
-    collector.endpoints.each do |endpoint|
-      ep = parse_endpoint(endpoint)
-
-      container_groups = []
-      ep.delete(:container_groups_refs).each do |ref|
-        next if ref.nil?
-        cg = lazy_find_container_group(:namespace => ref[:namespace], :name => ref[:name])
-        container_groups << cg unless cg.nil?
-      end
-      cgs_by_namespace_and_name.store_path(ep[:namespace], ep[:name], container_groups)
-    end
-
+  def services
     collector.services.each do |service|
-      h = parse_service(service)
-
-      h[:container_project] = lazy_find_project(:name => h[:namespace]) # TODO: untested?
-
-      # TODO: with multiple ports, how can I match any of them to known registries,
-      # like https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/57 ?
-      if h[:container_service_port_configs].any?
-        registry_port = h[:container_service_port_configs].last[:port]
-        h[:container_image_registry] = lazy_find_image_registry(
-          :host => h[:portal_ip], :port => registry_port
-        )
-      end
-
-      custom_attrs = h.extract!(:labels, :selector_parts)
-      tags = h.delete(:tags)
-      children = h.extract!(:container_service_port_configs)
-
-      h[:container_groups] = cgs_by_namespace_and_name.fetch_path(h[:namespace], h[:name]) || []
-
-      container_service = persister.container_services.build(h)
-
-      container_service_port_configs(container_service, children[:container_service_port_configs])
-      custom_attributes(container_service,
-                                  :labels    => custom_attrs[:labels],
-                                  # The actual section is "selectors"
-                                  :selectors => custom_attrs[:selector_parts])
-      taggings(container_service, tags)
+      parse_service(service)
     end
   end
 
@@ -423,27 +399,42 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
   def parse_service(service)
     new_result = parse_base_item(service)
 
-    if new_result[:ems_ref].nil? # Typically this happens for kubernetes services
-      new_result[:ems_ref] = "#{new_result[:namespace]}_#{new_result[:name]}"
-    end
+    # Typically this happens for kubernetes services
+    new_result[:ems_ref] = "#{new_result[:namespace]}_#{new_result[:name]}" if new_result[:ems_ref].nil?
 
-    labels = parse_labels(service)
+    labels         = parse_labels(service)
+    tags           = map_labels('ContainerService', labels)
+    selector_parts = parse_selector_parts(service)
+
+    container_groups = cgs_by_namespace_and_name.fetch_path(new_result[:namespace], new_result[:name]) || []
+
     new_result.merge!(
+      :container_project => lazy_find_project(:name => new_result[:namespace]),
       # TODO: We might want to change portal_ip to clusterIP
-      :portal_ip        => service.spec.clusterIP,
-      :session_affinity => service.spec.sessionAffinity,
-      :service_type     => service.spec.type,
-      :labels           => labels,
-      :tags             => map_labels('ContainerService', labels),
-      :selector_parts   => parse_selector_parts(service),
+      :portal_ip         => service.spec.clusterIP,
+      :session_affinity  => service.spec.sessionAffinity,
+      :service_type      => service.spec.type,
+      :container_groups  => container_groups
     )
 
-    ports = service.spec.ports
-    new_result[:container_service_port_configs] = Array(ports).collect do |port_entry|
+    container_service_port_configs = Array(service.spec.ports).collect do |port_entry|
       parse_service_port_config(port_entry, new_result[:ems_ref])
     end
 
-    new_result
+    # TODO: with multiple ports, how can I match any of them to known registries,
+    # like https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/57 ?
+    if container_service_port_configs.any?
+      registry_port = container_service_port_configs.last[:port]
+      new_result[:container_image_registry] = lazy_find_image_registry(:host => new_result[:portal_ip], :port => registry_port)
+    end
+
+    container_service = persister.container_services.build(new_result)
+
+    container_service_port_configs(container_service, container_service_port_configs)
+    custom_attributes(container_service, :labels => labels, :selectors => selector_parts)
+    taggings(container_service, tags)
+
+    container_service
   end
 
   def parse_pod(pod)

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
@@ -1,0 +1,110 @@
+class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
+  def parse
+    pods
+    services
+    endpoints
+    replication_controllers
+    nodes
+    namespaces
+    resource_quotas
+    limit_ranges
+    persistent_volumes
+    persistent_volume_claims
+  end
+
+  def pods
+    collector.pods.each do |notice|
+      pod = notice.object
+
+      persister.container_groups.targeted_scope << pod.metadata.uid
+      next if notice.type == "DELETED"
+
+      parse_pod(pod)
+    end
+  end
+
+  def services
+    # TODO: services depend on endpoints
+  end
+
+  def endpoints
+    # TODO: endpoints are only used for services
+  end
+
+  def replication_controllers
+    collector.replication_controllers.each do |notice|
+      replication_controller = notice.object
+
+      persister.container_replication_controllers.targeted_scope << replication_controller.metadata.uid
+      next if notice.type == "DELETED"
+
+      parse_replication_controller(replication_controller)
+    end
+  end
+
+  def nodes
+    collector.nodes.each do |notice|
+      node = notice.object
+
+      persister.container_nodes.targeted_scope << node.metadata.uid
+      next if notice.type == "DELETED"
+
+      parse_node(node)
+    end
+  end
+
+  def namespaces
+    collector.namespaces.each do |notice|
+      namespace = notice.object
+
+      persister.container_projects.targeted_scope << namespace.metadata.uid
+      next if notice.type == "DELETED"
+
+      parse_namespace(namespace)
+    end
+  end
+
+  def resource_quotas
+    collector.resource_quotas.each do |notice|
+      quota = notice.object
+
+      persister.container_quotas.targeted_scope << quota.metadata.uid
+      next if notice.type == "DELETED"
+
+      parse_resource_quota(quota)
+    end
+  end
+
+  def limit_ranges
+    collector.limit_ranges.each do |notice|
+      limit_range = notice.object
+
+      persister.container_limits.targeted_scope << limit_range.metadata.uid
+      next if notice.type == "DELETED"
+
+      parse_range(limit_range)
+    end
+  end
+
+  def persistent_volumes
+    collector.persistent_volumes.each do |notice|
+      pv = notice.object
+
+      persister.persistent_volumes.targeted_scope << pv.metadata.uid
+      next if notice.type == "DELETED"
+
+      parse_persistent_volume(pv)
+    end
+  end
+
+  def persistent_volume_claims
+    collector.persistent_volume_claims.each do |notice|
+      pvc = notice.object
+
+      persister.persistent_volume_claims.targeted_scope << pvc.metadata.uid
+      next if notice.type == "DELETED"
+
+      parse_persistent_volume_claim(pvc)
+    end
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
@@ -35,7 +35,7 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ
     collector.replication_controllers.each do |notice|
       replication_controller = notice.object
 
-      persister.container_replication_controllers.targeted_scope << replication_controller.metadata.uid
+      persister.container_replicators.targeted_scope << replication_controller.metadata.uid
       next if notice.type == "DELETED"
 
       parse_replication_controller(replication_controller)

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
@@ -2,7 +2,6 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ
   def parse
     pods
     services
-    endpoints
     replication_controllers
     nodes
     namespaces
@@ -24,11 +23,14 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ
   end
 
   def services
-    # TODO: services depend on endpoints
-  end
+    collector.services.each do |notice|
+      service = notice.object
 
-  def endpoints
-    # TODO: endpoints are only used for services
+      persister.container_services.targeted_scope << service.metadata.uid
+      next if notice.type == "DELETED"
+
+      parse_service(service)
+    end
   end
 
   def replication_controllers

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
@@ -1,5 +1,7 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
   def parse
+    parse_notices
+
     pods
     services
     replication_controllers
@@ -11,106 +13,17 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ
     persistent_volume_claims
   end
 
-  def pods
-    collector.pods.each do |notice|
-      pod = notice.object
+  def parse_notices
+    collector.notices.each do |notice|
+      object = notice.object
+      kind   = object.kind
 
-      persister.container_groups.targeted_scope << pod.metadata.uid
-      next if notice.type == "DELETED"
-
-      parse_pod(pod)
+      inventory_collection = persister.send(resource_by_entity(kind.underscore).tableize)
+      inventory_collection.targeted_scope << object.metadata.uid
     end
   end
 
   def cgs_by_namespace_and_name
     nil
-  end
-
-  def services
-    collector.services.each do |notice|
-      service = notice.object
-
-      persister.container_services.targeted_scope << service.metadata.uid
-      next if notice.type == "DELETED"
-
-      parse_service(service)
-    end
-  end
-
-  def replication_controllers
-    collector.replication_controllers.each do |notice|
-      replication_controller = notice.object
-
-      persister.container_replicators.targeted_scope << replication_controller.metadata.uid
-      next if notice.type == "DELETED"
-
-      parse_replication_controller(replication_controller)
-    end
-  end
-
-  def nodes
-    collector.nodes.each do |notice|
-      node = notice.object
-
-      persister.container_nodes.targeted_scope << node.metadata.uid
-      next if notice.type == "DELETED"
-
-      parse_node(node)
-    end
-  end
-
-  def namespaces
-    collector.namespaces.each do |notice|
-      namespace = notice.object
-
-      persister.container_projects.targeted_scope << namespace.metadata.uid
-      next if notice.type == "DELETED"
-
-      parse_namespace(namespace)
-    end
-  end
-
-  def resource_quotas
-    collector.resource_quotas.each do |notice|
-      quota = notice.object
-
-      persister.container_quotas.targeted_scope << quota.metadata.uid
-      next if notice.type == "DELETED"
-
-      parse_resource_quota(quota)
-    end
-  end
-
-  def limit_ranges
-    collector.limit_ranges.each do |notice|
-      limit_range = notice.object
-
-      persister.container_limits.targeted_scope << limit_range.metadata.uid
-      next if notice.type == "DELETED"
-
-      parse_range(limit_range)
-    end
-  end
-
-  def persistent_volumes
-    collector.persistent_volumes.each do |notice|
-      pv = notice.object
-
-      persister.persistent_volumes.targeted_scope << pv.metadata.uid
-      next if notice.type == "DELETED"
-
-      parse_persistent_volume(pv)
-    end
-  end
-
-  def persistent_volume_claims
-    collector.persistent_volume_claims.each do |notice|
-      pvc = notice.object
-
-      persister.persistent_volume_claims.targeted_scope << pvc.metadata.uid
-      next if notice.type == "DELETED"
-
-      parse_persistent_volume_claim(pvc)
-    end
   end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
@@ -22,6 +22,10 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ
     end
   end
 
+  def cgs_by_namespace_and_name
+    nil
+  end
+
   def services
     collector.services.each do |notice|
       service = notice.object

--- a/app/models/manageiq/providers/kubernetes/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :ContainerManager
+  require_nested :WatchNotice
 
   def add_collection_directly(collection)
     @collections[collection.name] = collection

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/watch_notice.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::Kubernetes::Inventory::Persister::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
+  def targeted?
+    true
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/watch_notice.rb
@@ -2,4 +2,8 @@ class ManageIQ::Providers::Kubernetes::Inventory::Persister::WatchNotice < Manag
   def targeted?
     true
   end
+
+  def strategy
+    :local_db_find_missing_references
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,7 +58,7 @@
 :ems_refresh:
   :kubernetes:
     :refresh_interval: 15.minutes
-    :streaming_refresh: false
+    :streaming_refresh: true
     :chunk_size: 1_000
     :inventory_collections:
       :saver_strategy: batch

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -721,6 +721,20 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
         targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_pvc)])
         expect(ems.persistent_volume_claims.pluck(:ems_ref)).to include(new_pvc.dig(:metadata, :uid))
       end
+
+      # The VCR for full-refresh doesn't have any persistent volume claims so we
+      # have to add a new one then modify/delete it
+      it "updated" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_pvc)])
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => new_pvc)])
+        expect(ems.persistent_volume_claims.pluck(:ems_ref)).to include(new_pvc.dig(:metadata, :uid))
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_pvc)])
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => new_pvc)])
+        expect(ems.persistent_volume_claims.pluck(:ems_ref)).not_to include(new_pvc.dig(:metadata, :uid))
+      end
     end
 
     context "pods" do

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/endpoint.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/endpoint.yml
@@ -1,16 +1,25 @@
 ---
 :metadata:
-  :name: kubernetes
+  :name: monitoring-grafana
   :namespace: default
-  :selfLink: "/api/v1/namespaces/default/endpoints/kubernetes"
-  :uid: 6668dc12-35f0-11e5-8917-001a4a5f4a00
-  :resourceVersion: '8'
-  :creationTimestamp: '2015-07-29T12:50:33Z'
+  :selfLink: "/api/v1/namespaces/default/endpoints/monitoring-grafana"
+  :uid: 1f3049d8-35f2-11e5-8917-001a4a5f4a00
+  :resourceVersion: '197'
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :kubernetes.io/cluster-service: 'true'
+    :kubernetes.io/name: monitoring-grafana
 :subsets:
 - :addresses:
-  - :ip: 10.35.0.169
+  - :ip: 172.17.0.2
+    :targetRef:
+      :kind: Pod
+      :namespace: default
+      :name: monitoring-influx-grafana-controller-22icy
+      :uid: 1f60be5d-35f2-11e5-8917-001a4a5f4a00
+      :resourceVersion: '194'
   :ports:
-  - :port: 6443
+  - :port: 8080
     :protocol: TCP
 :kind: Endpoint
 :apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/endpoint.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/endpoint.yml
@@ -1,0 +1,16 @@
+---
+:metadata:
+  :name: kubernetes
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/endpoints/kubernetes"
+  :uid: 6668dc12-35f0-11e5-8917-001a4a5f4a00
+  :resourceVersion: '8'
+  :creationTimestamp: '2015-07-29T12:50:33Z'
+:subsets:
+- :addresses:
+  - :ip: 10.35.0.169
+  :ports:
+  - :port: 6443
+    :protocol: TCP
+:kind: Endpoint
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/limit_range.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/limit_range.yml
@@ -1,0 +1,16 @@
+---
+:metadata:
+  :name: limits
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/limitranges/limits"
+  :uid: '081e3eb8-4035-11e5-b186-0aaeec44370e'
+  :resourceVersion: '497'
+  :creationTimestamp: '2015-08-11T14:27:01Z'
+:spec:
+  :limits:
+  - :type: Container
+    :default:
+      :cpu: 100m
+      :memory: 512Mi
+:kind: LimitRange
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/namespace.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/namespace.yml
@@ -1,0 +1,14 @@
+---
+:metadata:
+  :name: default
+  :selfLink: "/api/v1/namespaces/default"
+  :uid: 665eae8f-35f0-11e5-8917-001a4a5f4a00
+  :resourceVersion: '6'
+  :creationTimestamp: '2015-07-29T12:50:33Z'
+:spec:
+  :finalizers:
+  - kubernetes
+:status:
+  :phase: Active
+:kind: Namespace
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_limit_range.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_limit_range.yml
@@ -1,0 +1,16 @@
+---
+:metadata:
+  :name: limits4
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/limitranges/limits4"
+  :uid: 748b15c8-1dfc-4099-ab16-69395f232087
+  :resourceVersion: '497'
+  :creationTimestamp: '2015-08-11T14:27:01Z'
+:spec:
+  :limits:
+  - :type: Container
+    :default:
+      :cpu: 100m
+      :memory: 512Mi
+:kind: LimitRange
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_namespace.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_namespace.yml
@@ -1,0 +1,8 @@
+---
+:kind: Namespace
+:apiVersion: v1
+:metadata:
+  :name: my-new-project
+  :selfLink: "/api/v1/namespaces/my-new-project"
+  :uid: 9d5d61ed-b861-4140-9e64-8efc7048d10d
+  :resourceVersion: '750378'

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_node.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_node.yml
@@ -1,0 +1,36 @@
+---
+:metadata:
+  :name: 10.35.0.170
+  :selfLink: "/api/v1/nodes/10.35.0.170"
+  :uid: a4a9b6ec-4f11-4c0a-9fd9-043b51ed26d1
+  :resourceVersion: '5302'
+  :creationTimestamp: '2015-07-29T12:50:46Z'
+  :labels:
+    :kubernetes.io/hostname: 10.35.0.170
+:spec:
+  :externalID: 10.35.0.170
+:status:
+  :capacity:
+    :cpu: '2'
+    :memory: 2048080Ki
+    :pods: '40'
+  :conditions:
+  - :type: Ready
+    :status: 'True'
+    :lastHeartbeatTime: '2015-07-29T15:53:24Z'
+    :lastTransitionTime: '2015-07-29T12:50:46Z'
+    :reason: kubelet is posting ready status
+  :addresses:
+  - :type: LegacyHostIP
+    :address: 10.35.0.170
+  :nodeInfo:
+    :machineID: 8b6c70709abd41aca950e4cfad665673
+    :systemUUID: 8B6C7070-9ABD-41AC-A951-E4CFAC665673
+    :bootID: da9a3173-328f-4bd6-a423-17189d74e3a4
+    :kernelVersion: 3.18.9-100.fc20.x86_64
+    :osImage: Fedora 20 (Heisenbug)
+    :containerRuntimeVersion: docker://1.5.0
+    :kubeletVersion: v1.0.0-dirty
+    :kubeProxyVersion: v1.0.0-dirty
+:kind: Node
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_persistent_volume.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_persistent_volume.yml
@@ -1,0 +1,20 @@
+:metadata:
+  :name: pv0002
+  :selfLink: "/api/v1/persistentvolumes/pv0002"
+  :uid: 8503e3f6-b3b0-44cd-bedc-325fb497c7c3
+  :resourceVersion: '380779'
+  :creationTimestamp: '2015-08-24T14:21:43Z'
+  :labels:
+    :type: local
+:spec:
+  :capacity:
+    :storage: 20Gi
+  :hostPath:
+    :path: "/tmp/data02"
+  :accessModes:
+  - ReadWriteOnce
+  :persistentVolumeReclaimPolicy: Retain
+:status:
+  :phase: Available
+:kind: PersistentVolume
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_persistent_volume_claim.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_persistent_volume_claim.yml
@@ -1,0 +1,32 @@
+---
+:metadata:
+  :name: my-persistentvolumeclaim-0
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/persistentvolumeclaims/my-persistentvolumeclaim-0"
+  :uid: 9b0629a3-dadf-11e9-86a6-525400b7d5c1
+  :resourceVersion: '10335'
+  :creationTimestamp: '2019-09-19T13:15:52Z'
+  :annotations:
+    :pv.kubernetes.io/bind-completed: 'yes'
+    :pv.kubernetes.io/bound-by-controller: 'yes'
+  :finalizers:
+  - kubernetes.io/pvc-protection
+:spec:
+  :accessModes:
+  - ReadWriteOnce
+  :selector:
+    :matchLabels:
+      :my-pv-label: my-pv-0
+  :resources:
+    :requests:
+      :storage: 8Mi
+  :volumeName: my-persistentvolume-0
+  :storageClassName: manual
+:status:
+  :phase: Bound
+  :accessModes:
+  - ReadWriteOnce
+  :capacity:
+    :storage: 10Mi
+:kind: PersistentVolumeClaim
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_pod.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_pod.yml
@@ -1,0 +1,62 @@
+---
+:kind: Pod
+:apiVersion: v1
+:metadata:
+  :name: new-pod-4k5zu
+  :generateName: new-pod-
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/pods/new-pod-4k5zu"
+  :uid: 46cd0de6-7cf6-461b-8595-803b0e565dc0
+  :resourceVersion: '5253'
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :name: heapster
+  :annotations:
+    :kubernetes.io/created-by: '{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"default","name":"monitoring-heapster-controller","uid":"1f2d2157-35f2-11e5-8917-001a4a5f4a00","apiVersion":"v1","resourceVersion":"100"}}'
+:spec:
+  :volumes:
+  - :name: default-token-a2ui3
+    :secret:
+      :secretName: default-token-a2ui3
+  :containers:
+  - :name: heapster
+    :image: example.com:1234/kubernetes/heapster:v0.16.0
+    :command:
+    - "/heapster"
+    - "--source=kubernetes:https://kubernetes"
+    - "--sink=influxdb:http://monitoring-influxdb:80"
+    :resources: {}
+    :volumeMounts:
+    - :name: default-token-a2ui3
+      :readOnly: true
+      :mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+    :terminationMessagePath: "/dev/termination-log"
+    :imagePullPolicy: IfNotPresent
+  :restartPolicy: Always
+  :dnsPolicy: ClusterFirst
+  :serviceAccountName: default
+  :nodeName: 10.35.0.169
+:status:
+  :phase: Running
+  :conditions:
+  - :type: Ready
+    :status: 'True'
+  :hostIP: 10.35.0.169
+  :podIP: 172.17.0.4
+  :startTime: '2015-07-29T13:02:53Z'
+  :containerStatuses:
+  - :name: heapster
+    :state:
+      :running:
+        :startedAt: '2015-07-29T15:49:04Z'
+    :lastState:
+      :terminated:
+        :exitCode: 1
+        :startedAt: '2015-07-29T15:48:42Z'
+        :finishedAt: '2015-07-29T15:48:42Z'
+        :containerID: docker://7780ef155c1d87a3f8a36a6ad5a6a3e25cdc4f9c90693276c32c924ca603382d
+    :ready: true
+    :restartCount: 2
+    :image: example.com:1234/kubernetes/heapster:v0.16.0
+    :imageID: docker://f79cf2701046bea8d5f1384f7efe79dd4d20620b3594fff5be39142fa862259d
+    :containerID: docker://2baa337fef20ab18c5cae16937fca0b4a59ccbb5ecac1f89ad7898a02d74e3c9

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_replication_controller.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_replication_controller.yml
@@ -1,0 +1,38 @@
+---
+:metadata:
+  :name: new-monitoring-heapster-controller
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/replicationcontrollers/monitoring-heapster-controller"
+  :uid: 66eddb27-7f75-43f6-aafc-425c4aac9e63
+  :resourceVersion: '122'
+  :generation: 1
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :name: heapster
+:spec:
+  :replicas: 1
+  :selector:
+    :name: heapster
+  :template:
+    :metadata:
+      :creationTimestamp:
+      :labels:
+        :name: heapster
+    :spec:
+      :containers:
+      - :name: heapster
+        :image: kubernetes/heapster:v0.16.0
+        :command:
+        - "/heapster"
+        - "--source=kubernetes:https://kubernetes"
+        - "--sink=influxdb:http://monitoring-influxdb:80"
+        :resources: {}
+        :terminationMessagePath: "/dev/termination-log"
+        :imagePullPolicy: IfNotPresent
+      :restartPolicy: Always
+      :dnsPolicy: ClusterFirst
+:status:
+  :replicas: 1
+  :observedGeneration: 1
+:kind: ReplicationController
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_resource_quota.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_resource_quota.yml
@@ -1,0 +1,17 @@
+:metadata:
+  :name: quota3
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/resourcequotas/quota3"
+  :uid: c282c024-0fbd-485d-ae63-5f64489aaec6
+  :resourceVersion: '165339'
+  :creationTimestamp: '2015-08-17T09:16:46Z'
+:spec:
+  :hard:
+    :cpu: '30'
+:status:
+  :hard:
+    :cpu: '30'
+  :used:
+    :cpu: 100m
+:kind: ResourceQuota
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_service.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_service.yml
@@ -1,14 +1,14 @@
 ---
 :metadata:
-  :name: monitoring-grafana
+  :name: monitoring-grafana-2
   :namespace: default
-  :selfLink: "/api/v1/namespaces/default/services/monitoring-grafana"
-  :uid: 1f1b4bc0-35f2-11e5-8917-001a4a5f4a00
+  :selfLink: "/api/v1/namespaces/default/services/monitoring-grafana-2"
+  :uid: 41ebdba8-4aed-4f4c-a588-84945a672cfe
   :resourceVersion: '99'
   :creationTimestamp: '2015-07-29T13:02:52Z'
   :labels:
     :kubernetes.io/cluster-service: 'true'
-    :kubernetes.io/name: monitoring-grafana
+    :kubernetes.io/name: monitoring-grafana-2
 :spec:
   :ports:
   - :protocol: TCP

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/node.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/node.yml
@@ -1,0 +1,36 @@
+---
+:metadata:
+  :name: 10.35.0.169
+  :selfLink: "/api/v1/nodes/10.35.0.169"
+  :uid: 6de77025-35f0-11e5-8917-001a4a5f4a00
+  :resourceVersion: '5302'
+  :creationTimestamp: '2015-07-29T12:50:45Z'
+  :labels:
+    :kubernetes.io/hostname: 10.35.0.169
+:spec:
+  :externalID: 10.35.0.169
+:status:
+  :capacity:
+    :cpu: '2'
+    :memory: 2048080Ki
+    :pods: '40'
+  :conditions:
+  - :type: Ready
+    :status: 'True'
+    :lastHeartbeatTime: '2015-07-29T15:53:23Z'
+    :lastTransitionTime: '2015-07-29T12:50:45Z'
+    :reason: kubelet is posting ready status
+  :addresses:
+  - :type: LegacyHostIP
+    :address: 10.35.0.169
+  :nodeInfo:
+    :machineID: 8b6c70709abd41aca950e4cfac665673
+    :systemUUID: 8B6C7070-9ABD-41AC-A950-E4CFAC665673
+    :bootID: da9a3173-328f-4bd6-a422-17189d74e3a4
+    :kernelVersion: 3.18.9-100.fc20.x86_64
+    :osImage: Fedora 20 (Heisenbug)
+    :containerRuntimeVersion: docker://1.5.0
+    :kubeletVersion: v1.0.0-dirty
+    :kubeProxyVersion: v1.0.0-dirty
+:kind: Node
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/persistent_volume.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/persistent_volume.yml
@@ -1,0 +1,20 @@
+:metadata:
+  :name: pv0001
+  :selfLink: "/api/v1/persistentvolumes/pv0001"
+  :uid: 71e4aa67-4a6b-11e5-b186-0aaeec44370e
+  :resourceVersion: '380779'
+  :creationTimestamp: '2015-08-24T14:21:43Z'
+  :labels:
+    :type: local
+:spec:
+  :capacity:
+    :storage: 10Gi
+  :hostPath:
+    :path: "/tmp/data01"
+  :accessModes:
+  - ReadWriteOnce
+  :persistentVolumeReclaimPolicy: Retain
+:status:
+  :phase: Available
+:kind: PersistentVolume
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/pod.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/pod.yml
@@ -1,0 +1,62 @@
+---
+:metadata:
+  :name: monitoring-heapster-controller-4j5zu
+  :generateName: monitoring-heapster-controller-
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/pods/monitoring-heapster-controller-4j5zu"
+  :uid: 1f60bc7c-35f2-11e5-8917-001a4a5f4a00
+  :resourceVersion: '5253'
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :name: heapster
+  :annotations:
+    :kubernetes.io/created-by: '{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"default","name":"monitoring-heapster-controller","uid":"1f2d2157-35f2-11e5-8917-001a4a5f4a00","apiVersion":"v1","resourceVersion":"100"}}'
+:spec:
+  :volumes:
+  - :name: default-token-a2ui3
+    :secret:
+      :secretName: default-token-a2ui3
+  :containers:
+  - :name: heapster
+    :image: example.com:1234/kubernetes/heapster:v0.16.0
+    :command:
+    - "/heapster"
+    - "--source=kubernetes:https://kubernetes"
+    - "--sink=influxdb:http://monitoring-influxdb:80"
+    :resources: {}
+    :volumeMounts:
+    - :name: default-token-a2ui3
+      :readOnly: true
+      :mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+    :terminationMessagePath: "/dev/termination-log"
+    :imagePullPolicy: IfNotPresent
+  :restartPolicy: Always
+  :dnsPolicy: ClusterFirst
+  :serviceAccountName: default
+  :nodeName: 10.35.0.169
+:status:
+  :phase: Running
+  :conditions:
+  - :type: Ready
+    :status: 'True'
+  :hostIP: 10.35.0.169
+  :podIP: 172.17.0.3
+  :startTime: '2015-07-29T13:02:53Z'
+  :containerStatuses:
+  - :name: heapster
+    :state:
+      :running:
+        :startedAt: '2015-07-29T15:49:04Z'
+    :lastState:
+      :terminated:
+        :exitCode: 1
+        :startedAt: '2015-07-29T15:48:42Z'
+        :finishedAt: '2015-07-29T15:48:42Z'
+        :containerID: docker://7780ef155c1d87a3f8a36a6ad5a6a3e25cdc4f9c90693276c32c924ca603382d
+    :ready: true
+    :restartCount: 2
+    :image: example.com:1234/kubernetes/heapster:v0.16.0
+    :imageID: docker://f79cf2701046bea8d5f1384f7efe79dd4d20620b3594fff5be39142fa862259d
+    :containerID: docker://2baa337fef20ab18c5cae16937fca0b4a59ccbb5ecac1f89ad7898a02d74e3c9
+:kind: Pod
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/replication_controller.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/replication_controller.yml
@@ -1,0 +1,38 @@
+---
+:metadata:
+  :name: monitoring-heapster-controller
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/replicationcontrollers/monitoring-heapster-controller"
+  :uid: 1f2d2157-35f2-11e5-8917-001a4a5f4a00
+  :resourceVersion: '122'
+  :generation: 1
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :name: heapster
+:spec:
+  :replicas: 1
+  :selector:
+    :name: heapster
+  :template:
+    :metadata:
+      :creationTimestamp:
+      :labels:
+        :name: heapster
+    :spec:
+      :containers:
+      - :name: heapster
+        :image: kubernetes/heapster:v0.16.0
+        :command:
+        - "/heapster"
+        - "--source=kubernetes:https://kubernetes"
+        - "--sink=influxdb:http://monitoring-influxdb:80"
+        :resources: {}
+        :terminationMessagePath: "/dev/termination-log"
+        :imagePullPolicy: IfNotPresent
+      :restartPolicy: Always
+      :dnsPolicy: ClusterFirst
+:status:
+  :replicas: 1
+  :observedGeneration: 1
+:kind: ReplicationController
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/resource_quota.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/resource_quota.yml
@@ -1,0 +1,17 @@
+:metadata:
+  :name: quota2
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/resourcequotas/quota2"
+  :uid: af3d1a10-44c0-11e5-b186-0aaeec44370e
+  :resourceVersion: '165339'
+  :creationTimestamp: '2015-08-17T09:16:46Z'
+:spec:
+  :hard:
+    :cpu: '30'
+:status:
+  :hard:
+    :cpu: '30'
+  :used:
+    :cpu: 100m
+:kind: ResourceQuota
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/service.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/service.yml
@@ -1,0 +1,24 @@
+---
+:metadata:
+  :name: kubernetes
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/services/kubernetes"
+  :uid: 666332a1-35f0-11e5-8917-001a4a5f4a00
+  :resourceVersion: '7'
+  :creationTimestamp: '2015-07-29T12:50:33Z'
+  :labels:
+    :component: apiserver
+    :provider: kubernetes
+:spec:
+  :ports:
+  - :protocol: TCP
+    :port: 443
+    :targetPort: 443
+    :nodePort: 0
+  :clusterIP: 10.0.0.1
+  :type: ClusterIP
+  :sessionAffinity: None
+:status:
+  :loadBalancer: {}
+:kind: Service
+:apiVersion: v1


### PR DESCRIPTION
Use kubernetes watches for targeted refresh of ContainerManager entities

TODO:
- [x] Allow streaming refresh able to be disabled by settings
- [x] Restart watches if a user initiates a full refresh
- [x] Handle 410 Gone status (moving full refresh to be per entity would simplify watch restart)
- [x] Add specs covering all ADDED/MODIFIED/DELETED for all entity types
  - [x] pods
  - [x] services
  - [ ] ~~endpoints (These are weird because endpoints are used by services but not saved directly)~~ These are going to take more work, going to do a follow-up for this.  For now these will be updated every full refresh
  - [x] replication_controllers
  - [x] nodes
  - [x] namespaces
  - [x] resource_quotas
  - [x] limit_ranges
  - [x] persistent_volumes
  - [x] persistent_volume_claims
- [x] Targeted refresh parsing of a pod's container_image

Depends: 
- [x] https://github.com/ManageIQ/manageiq/pull/20098

https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/369