### PR TITLE
Bump kubeclient to newer version

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("hawkular-client",                 "~> 4.1")
   s.add_runtime_dependency("image-inspector-client",          "~> 2.0")
-  s.add_runtime_dependency("kubeclient",                      "~> 4.1", ">= 4.1.1")
+  s.add_runtime_dependency("kubeclient",                      "~> 4.3")
   s.add_runtime_dependency("prometheus-alert-buffer-client",  "~> 0.2.0")
   s.add_runtime_dependency("prometheus-api-client",           "~> 0.6")
   s.add_runtime_dependency("more_core_extensions",            "~> 3.6")


### PR DESCRIPTION
Kubeclient is up to 4.6 and we were back on 4.1.  We can't update past 4.3 yet because of kubevirt but this gets us closer