### PR TITLE
Add targeted refresh for services and endpoints

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
@@ -50,7 +50,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner <
   end
 
   def kubernetes_entity_types
-    %w[pods services replication_controllers nodes namespaces resource_quotas limit_ranges persistent_volumes persistent_volume_claims].freeze
+    %w[pods services endpoints replication_controllers nodes namespaces resource_quotas limit_ranges persistent_volumes persistent_volume_claims].freeze
   end
 
   def entity_types

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
@@ -50,7 +50,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner <
   end
 
   def kubernetes_entity_types
-    %w[pods replication_controllers nodes namespaces resource_quotas limit_ranges persistent_volumes persistent_volume_claims].freeze
+    %w[pods services replication_controllers nodes namespaces resource_quotas limit_ranges persistent_volumes persistent_volume_claims].freeze
   end
 
   def entity_types

--- a/app/models/manageiq/providers/kubernetes/inventory/collector.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector.rb
@@ -1,4 +1,14 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   require_nested :ContainerManager
   require_nested :WatchNotice
+
+  def connect(service)
+    manager.connect(:service => service)
+  rescue KubeException
+    nil
+  end
+
+  def kubernetes_connection
+    @kubernetes_connection ||= connect("kubernetes")
+  end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
@@ -49,16 +49,6 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager < 
     Settings.ems_refresh[manager.class.ems_type]
   end
 
-  def connect(service)
-    manager.connect(:service => service)
-  rescue KubeException
-    nil
-  end
-
-  def kubernetes_connection
-    @kubernetes_connection ||= connect("kubernetes")
-  end
-
   def fetch_entity(client, entity)
     meth = "get_#{entity}"
 

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/watch_notice.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Collector
-  attr_reader :additional_attributes, :pods, :services, :endpoints, :replication_controllers,
+  attr_reader :additional_attributes, :pods, :services, :replication_controllers,
               :namespaces, :nodes, :notices, :resource_quotas, :limit_ranges,
               :persistent_volumes, :persistent_volume_claims
 
@@ -12,13 +12,24 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice < Manag
     super(manager, nil)
   end
 
+  def endpoints
+    @endpoints ||= begin
+      services.each_with_object([]) do |service, results|
+        begin
+          endpoint = kubernetes_connection.get_endpoint(service.metadata.name, service.metadata.namespace)
+          results << endpoint
+        rescue Kubeclient::ResourceNotFoundError
+        end
+      end
+    end
+  end
+
   private
 
   def initialize_collections!
     @additional_attributes    = {}
     @pods                     = []
     @services                 = []
-    @endpoints                = []
     @replication_controllers  = []
     @nodes                    = []
     @namespaces               = []

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
@@ -18,6 +18,9 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ
       object = notice.object
       kind   = object.kind
 
+      collection_name = resource_by_entity(kind.underscore)
+      next if collection_name.nil?
+
       inventory_collection = persister.send(resource_by_entity(kind.underscore).tableize)
       inventory_collection.targeted_scope << object.metadata.uid
     end

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
@@ -22,8 +22,4 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ
       inventory_collection.targeted_scope << object.metadata.uid
     end
   end
-
-  def cgs_by_namespace_and_name
-    nil
-  end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -871,9 +871,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
 
         targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => endpoint)])
 
-        container_service = ems.container_projects
-          .find_by(:name => endpoint.dig(:metadata, :namespace))
-          .container_services.find_by(:name => endpoint.dig(:metadata, :name))
+        container_project = ems.container_projects.find_by(:name => endpoint.dig(:metadata, :namespace))
+        container_service = container_project.container_services.find_by(:name => endpoint.dig(:metadata, :name))
 
         expect(container_service.reload.container_groups.count).to eq(2)
       end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -850,6 +850,11 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
     end
 
     def targeted_refresh(notices)
+      endpoint = Kubeclient::Resource.new(load_watch_notice_data("endpoint"))
+      kube = double("Kubeclient::Client")
+      allow(kube).to receive(:get_endpoint).and_return(endpoint)
+      allow(ems).to receive(:connect).and_return(kube)
+
       collector = ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice.new(ems, notices)
       persister = ManageIQ::Providers::Kubernetes::Inventory::Persister::WatchNotice.new(ems, nil)
       parser    = ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice.new

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -849,10 +849,48 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       end
     end
 
+    context "endpoints" do
+      let(:endpoint) { load_watch_notice_data("endpoint") }
+
+      it "created" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => endpoint)])
+        expect(ems.container_services.pluck(:name)).to include(endpoint.dig(:metadata, :name))
+      end
+
+      it "updated" do
+        endpoint[:subsets][0][:addresses] << {
+          :ip        => "172.17.0.3",
+          :targetRef => {
+            :kind            => "Pod",
+            :namespace       => "default",
+            :name            => "monitoring-heapster-controller-4j5zu",
+            :uid             => "1f60be5d-35f2-11e5-8917-001a4a5f4a00",
+            :resourceVersion => "195"
+          }
+        }
+
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => endpoint)])
+
+        container_service = ems.container_projects
+          .find_by(:name => endpoint.dig(:metadata, :namespace))
+          .container_services.find_by(:name => endpoint.dig(:metadata, :name))
+
+        expect(container_service.reload.container_groups.count).to eq(2)
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => endpoint)])
+        expect(ems.container_services.pluck(:name)).to include(endpoint.dig(:metadata, :name))
+      end
+    end
+
     def targeted_refresh(notices)
       endpoint = Kubeclient::Resource.new(load_watch_notice_data("endpoint"))
+      service  = Kubeclient::Resource.new(load_watch_notice_data("service"))
+
       kube = double("Kubeclient::Client")
       allow(kube).to receive(:get_endpoint).and_return(endpoint)
+      allow(kube).to receive(:get_service).and_return(service)
       allow(ems).to receive(:connect).and_return(kube)
 
       collector = ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice.new(ems, notices)

--- a/spec/models/manageiq/providers/kubernetes/inventory/collector/watch_notice_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/inventory/collector/watch_notice_spec.rb
@@ -1,0 +1,91 @@
+autoload(:Kubeclient, 'kubeclient')
+
+describe ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice do
+  let(:ems)       { FactoryBot.create(:ems_kubernetes) }
+  let(:collector) { ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice.new(ems, notices) }
+  let(:service1)  { Kubeclient::Resource.new(:kind => "Service", :metadata => {:name => "app1", :namespace => "default"}) }
+  let(:service2)  { Kubeclient::Resource.new(:kind => "Service", :metadata => {:name => "app2", :namespace => "default"}) }
+  let(:endpoint1) { Kubeclient::Resource.new(:kind => "Endpoint", :metadata => {:name => "app1", :namespace => "default"}) }
+  let(:endpoint2) { Kubeclient::Resource.new(:kind => "Endpoint", :metadata => {:name => "app2", :namespace => "default"}) }
+  let(:notices)   { [] }
+
+  context "with no notices" do
+    it "#endpoints" do
+      expect(collector.endpoints).to be_empty
+    end
+
+    it "#services" do
+      expect(collector.services).to be_empty
+    end
+  end
+
+  context "with a service notice" do
+    let(:service_notice)  { Kubeclient::Resource.new(:type => "MODIFIED", :object => service1) }
+    let(:notices)         { [service_notice] }
+
+    it "#endpoints" do
+      kubeclient = double("Kubeclient::Client")
+      expect(ems).to receive(:connect).and_return(kubeclient)
+      expect(kubeclient).to receive(:get_endpoint).with("app1", "default").and_return(endpoint1)
+
+      expect(collector.endpoints).to include(endpoint1)
+    end
+
+    it "#services" do
+      expect(collector.services).to include(service1)
+    end
+  end
+
+  context "with an endpoint notice" do
+    let(:endpoint_notice) { Kubeclient::Resource.new(:type => "MODIFIED", :object => endpoint1) }
+    let(:notices)         { [endpoint_notice] }
+
+    it "#services" do
+      kubeclient = double("Kubeclient::Client")
+      expect(ems).to receive(:connect).and_return(kubeclient)
+      expect(kubeclient).to receive(:get_service).with("app1", "default").and_return(service1)
+
+      expect(collector.services).to include(service1)
+    end
+
+    it "#endpoints" do
+      expect(collector.endpoints).to include(endpoint1)
+    end
+  end
+
+  context "with an endpoint and a service with the same name and namespace" do
+    let(:service_notice)  { Kubeclient::Resource.new(:type => "MODIFIED", :object => service1) }
+    let(:endpoint_notice) { Kubeclient::Resource.new(:type => "MODIFIED", :object => endpoint1) }
+    let(:notices)         { [service_notice, endpoint_notice] }
+
+    it "#endpoints" do
+      expect(collector.endpoints).to include(endpoint1)
+    end
+
+    it "#services" do
+      expect(collector.services).to include(service1)
+    end
+  end
+
+  context "with different endpoint and service notices" do
+    let(:service_notice)  { Kubeclient::Resource.new(:type => "MODIFIED", :object => service1) }
+    let(:endpoint_notice) { Kubeclient::Resource.new(:type => "MODIFIED", :object => endpoint2) }
+    let(:notices)         { [service_notice, endpoint_notice] }
+
+    it "#endpoints" do
+      kubeclient = double("Kubeclient::Client")
+      expect(ems).to receive(:connect).and_return(kubeclient)
+      expect(kubeclient).to receive(:get_endpoint).with("app1", "default").and_return(endpoint1)
+
+      expect(collector.endpoints).to include(endpoint1, endpoint2)
+    end
+
+    it "#services" do
+      kubeclient = double("Kubeclient::Client")
+      expect(ems).to receive(:connect).and_return(kubeclient)
+      expect(kubeclient).to receive(:get_service).with("app2", "default").and_return(service2)
+
+      expect(collector.services).to include(service1, service2)
+    end
+  end
+end


### PR DESCRIPTION
Services and endpoints are different k8s collections but are combined into one model in the MIQ refresh parser.  This means we cannot parse these as standalone notices like the other collections.

If we get a notice about either an endpoint or a service, perform a get_ for the other to allow the parser to work normally.

Followup to https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/366