### PR TITLE
[JANSA] Use watches for targeted refresh

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker.rb
@@ -1,3 +1,4 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
   require_nested :Runner
+  require_nested :WatchThread
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
@@ -1,2 +1,188 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner < ManageIQ::Providers::BaseManager::RefreshWorker::Runner
+  def after_initialize
+    super
+
+    @ems    = ExtManagementSystem.find(@cfg[:ems_id])
+    @finish = Concurrent::AtomicBoolean.new
+    @queue  = Queue.new
+
+    @refresher_thread           = nil
+    @refresh_notice_threshold   = 100
+    @collector_threads          = {}
+    @resource_version_by_entity = {}
+  end
+
+  def do_before_work_loop
+    # Prime the entities' resourceVersions by performing an initial full refresh
+    # if we're using streaming refresh, otherwise queue an initial full the standard way
+    streaming_refresh? ? full_refresh : super
+  end
+
+  def do_work
+    streaming_refresh? ? ensure_threads : stop_threads
+
+    super
+  end
+
+  def deliver_queue_message(msg)
+    # If we are using streaming refresh a user initiated full refresh should
+    # do a full refresh and restart the collector threads
+    if streaming_refresh?
+      super { restart_inventory_collector if full_refresh_queued?(msg) }
+    else
+      super
+    end
+  end
+
+  def before_exit(_message, _exit_code)
+    stop_threads if streaming_refresh?
+  end
+
+  private
+
+  attr_accessor :collector_threads, :refresher_thread
+  attr_reader   :ems, :finish, :queue, :refresh_notice_threshold, :resource_version_by_entity
+
+  def restart_inventory_collector
+    stop_collector_threads
+    full_refresh
+    ensure_collector_threads
+  end
+
+  def kubernetes_entity_types
+    %w[pods replication_controllers nodes namespaces resource_quotas limit_ranges persistent_volumes persistent_volume_claims].freeze
+  end
+
+  def entity_types
+    kubernetes_entity_types
+  end
+
+  def refresh_block
+    yield
+
+    ems.update!(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
+  rescue => err
+    _log.error("#{log_header} Refresh failed: #{err}")
+    _log.log_backtrace(err)
+    ems.update!(:last_refresh_error => err.to_s, :last_refresh_date => Time.now.utc)
+  end
+
+  def save_resource_versions(collector)
+    entity_types.each { |entity| resource_version_by_entity[entity] = collector.send(entity).resourceVersion }
+  end
+
+  def full_refresh
+    refresh_block do
+      inventory = inventory_klass.build(ems, nil)
+      inventory.parse
+      inventory.persister.persist!
+
+      save_resource_versions(inventory.collector)
+    end
+  end
+
+  def partial_refresh(notices)
+    refresh_block do
+      collector = inventory_klass::Collector::WatchNotice.new(ems, notices)
+      persister = inventory_klass::Persister::WatchNotice.new(ems, nil)
+      parser    = inventory_klass::Parser::WatchNotice.new
+
+      parser.collector = collector
+      parser.persister = persister
+      parser.parse
+      persister.persist!
+    end
+  end
+
+  def ensure_threads
+    ensure_refresher_thread
+    ensure_collector_threads
+  end
+
+  def stop_threads
+    finish.make_true
+    stop_collector_threads
+    stop_refresher_thread
+  end
+
+  def ensure_refresher_thread
+    self.refresher_thread = start_refresher_thread unless refresher_thread&.alive?
+  end
+
+  def start_refresher_thread
+    Thread.new { refresher }
+  end
+
+  def stop_refresher_thread
+    return unless refresher_thread&.alive?
+
+    queue.push(nil) # Push a nil to unblock the refresher thread
+    refresher_thread.join(10)
+  end
+
+  def refresher
+    _log.debug("#{log_header} Starting refresher thread")
+
+    loop do
+      notices = []
+
+      # Use queue.pop to block until an item is in the queue
+      notices << queue.pop
+
+      break if finish.true?
+
+      # Then continue to pop without blocking until the queue is empty
+      notices << queue.pop until queue.empty? || notices.count > refresh_notice_threshold
+      notices.compact!
+
+      _log.debug { "#{log_header} Refreshing #{notices.count} total notices" }
+      notices_by_kind = notices.group_by { |notice| notice.object.kind }
+      notices_by_kind.each do |kind, n|
+        _log.debug { "#{log_header}   #{kind}: #{n.count} notices" }
+      end
+      partial_refresh(notices)
+    end
+
+    _log.debug { "#{log_header} Exiting refresher thread" }
+  end
+
+  def ensure_collector_threads
+    entity_types.each do |entity_type|
+      next if collector_threads[entity_type]&.alive?
+
+      collector_threads[entity_type] = start_collector_thread(entity_type)
+    end
+  end
+
+  def start_collector_thread(entity_type)
+    ems.class::RefreshWorker::WatchThread.start!(ems, queue, entity_type, resource_version_by_entity[entity_type])
+  end
+
+  def stop_collector_threads
+    collector_threads.each_value(&:stop!)
+  end
+
+  def refresh_queued?(msg)
+    msg.class_name == "EmsRefresh" && msg.method_name == "refresh"
+  end
+
+  def full_refresh_queued?(msg)
+    refresh_queued?(msg) && msg.data.any? { |klass, _id| klass == ems.class.name }
+  end
+
+  def streaming_refresh?
+    refresher_options&.streaming_refresh
+  end
+
+  def refresher_options
+    Settings.ems_refresh[ems.emstype]
+  end
+
+  def inventory_klass
+    @inventory_klass ||= "#{ManageIQ::Providers::Inflector.provider_module(ems.class)}::Inventory".constantize
+  end
+
+  def log_header
+    @log_header ||= "EMS [#{ems.name}], id: [#{ems.id}]"
+  end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
@@ -1,0 +1,74 @@
+class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::WatchThread
+  include Vmdb::Logging
+
+  def self.start!(ems, queue, entity_type, resource_version)
+    new(ems.connect_options, ems.class, queue, entity_type, resource_version).tap(&:start!)
+  end
+
+  def initialize(connect_options, ems_klass, queue, entity_type, resource_version)
+    @connect_options = connect_options
+    @ems_klass       = ems_klass
+    @entity_type     = entity_type
+    @finish          = Concurrent::AtomicBoolean.new
+    @queue           = queue
+
+    self.resource_version = resource_version
+  end
+
+  def alive?
+    thread&.alive?
+  end
+
+  def start!
+    self.thread = Thread.new { collector_thread }
+  end
+
+  def stop!(join_limit = 10.seconds)
+    return unless alive?
+
+    finish.make_true
+    watch&.finish
+    thread&.join(join_limit)
+  end
+
+  private
+
+  attr_reader :connect_options, :ems_klass, :entity_type, :finish, :queue
+  attr_accessor :resource_version, :thread, :watch
+
+  def collector_thread
+    _log.debug { "Starting watch thread for #{entity_type}" }
+
+    until finish.true?
+      self.watch ||= connection(entity_type).send("watch_#{entity_type}", :resource_version => resource_version)
+
+      watch.each do |notice|
+        # If we get a 410 gone with this resource version break out and restart
+        # the watch
+        if notice.kind == "Status" && notice.code == 410
+          _log.warn("Caught 410 Gone, restarting watch")
+          break
+        end
+
+        queue.push(notice)
+      end
+
+      # If the watch terminated for any reason (410 Gone or just interrupted) then
+      # restart with a resourceVersion of nil to start over from the current state
+      self.watch = nil
+      self.resource_version = nil
+    end
+
+    _log.debug { "Exiting watch thread #{entity_type}" }
+  rescue => err
+    _log.error("Watch thread for #{entity_type} failed: #{err}")
+    _log.log_backtrace(err)
+  end
+
+  def connection(_entity_type = nil)
+    hostname, port = connect_options.values_at(:hostname, :port)
+    connect_options[:service] ||= "kubernetes"
+
+    ems_klass.raw_connect(hostname, port, connect_options)
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector.rb
@@ -1,3 +1,4 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   require_nested :ContainerManager
+  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
@@ -62,17 +62,22 @@ class ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager < 
   def fetch_entity(client, entity)
     meth = "get_#{entity}"
 
-    continue = nil
+    continue = resource_version = kind = nil
     results = []
 
     loop do
       result = client.send(meth, :limit => refresher_options.chunk_size, :continue => continue)
+      break if result.nil?
+
+      kind = result.kind
+      resource_version = result.resourceVersion
+
       results += result
       break if result.last?
 
       continue = result.continue
     end
 
-    results
+    Kubeclient::Common::EntityList.new(kind, resource_version, results)
   end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/watch_notice.rb
@@ -1,0 +1,51 @@
+class ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Collector
+  attr_reader :additional_attributes, :pods, :services, :endpoints, :replication_controllers,
+              :namespaces, :nodes, :notices, :resource_quotas, :limit_ranges,
+              :persistent_volumes, :persistent_volume_claims
+
+  def initialize(manager, notices)
+    @notices = filter_notices(notices)
+
+    initialize_collections!
+    populate_collections!
+
+    super(manager, nil)
+  end
+
+  private
+
+  def initialize_collections!
+    @additional_attributes    = {}
+    @pods                     = []
+    @services                 = []
+    @endpoints                = []
+    @replication_controllers  = []
+    @nodes                    = []
+    @namespaces               = []
+    @resource_quotas          = []
+    @limit_ranges             = []
+    @persistent_volumes       = []
+    @persistent_volume_claims = []
+  end
+
+  # The notices returned by the Kubernetes API contain always the complete
+  # representation of the object, so it isn't necessary to process all of them,
+  # only the last one for each object.
+  def filter_notices(all_notices)
+    notices_by_kind = all_notices.group_by { |notice| notice.object&.kind }.except(nil)
+
+    notices_by_kind.values.each_with_object([]) do |notices, result|
+      notices.reverse!.uniq! { |n| n.object&.metadata&.uid }
+      result.concat(notices)
+    end
+  end
+
+  # Pull the object out of the notices and populate the normal collections
+  # so that the Parser::ContainerManager can be used normally
+  def populate_collections!
+    # Only add ADDED/MODIFIED to the collectors so deleted objects will be removed
+    notices.reject { |n| n.type == "DELETED" }.each do |notice|
+      instance_variable_get("@#{notice.object.kind.tableize}") << notice.object
+    end
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   require_nested :ContainerManager
+  require_nested :WatchNotice
 
   def refresher_options
     Settings.ems_refresh[persister.manager.class.ems_type]

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -44,173 +44,49 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
 
   def nodes
     collector.nodes.each do |data|
-      h = parse_node(data)
-
-      h.except!(:namespace)
-
-      labels = h.delete(:labels)
-      tags = h.delete(:tags)
-      children = h.extract!(:container_conditions, :computer_system)
-
-      container_node = persister.container_nodes.build(h)
-
-      container_conditions(container_node, children[:container_conditions])
-      node_computer_systems(container_node, children[:computer_system])
-      custom_attributes(container_node, :labels => labels)
-      taggings(container_node, tags)
+      parse_node(data)
     end
-  end
-
-  def node_computer_systems(parent, hash)
-    return if hash.nil?
-
-    hash[:managed_entity] = parent
-    children = hash.extract!(:hardware, :operating_system)
-
-    computer_system = persister.computer_systems.build(hash)
-
-    node_computer_system_hardware(computer_system, children[:hardware])
-    node_computer_system_operating_system(computer_system, children[:operating_system])
-  end
-
-  def node_computer_system_hardware(parent, hash)
-    return if hash.nil?
-    hash[:computer_system] = parent
-    persister.computer_system_hardwares.build(hash)
-  end
-
-  def node_computer_system_operating_system(parent, hash)
-    return if hash.nil?
-    hash[:computer_system] = parent
-    persister.computer_system_operating_systems.build(hash)
   end
 
   def namespaces
     collector.namespaces.each do |ns|
-      h = parse_namespace(ns)
-
-      custom_attrs = h.extract!(:labels)
-      tags = h.delete(:tags)
-
-      container_project = persister.container_projects.build(h)
-
-      custom_attributes(container_project, custom_attrs) # TODO: untested
-      taggings(container_project, tags)
+      parse_namespace(ns)
     end
   end
 
   def resource_quotas
     collector.resource_quotas.each do |quota|
-      h = parse_resource_quota(quota)
-
-      h[:container_project] = lazy_find_project(:name => h[:namespace])
-
-      scopes = h.delete(:container_quota_scopes)
-      items = h.delete(:container_quota_items)
-      container_quota = persister.container_quotas.build(h)
-
-      container_quota_scopess(container_quota, scopes)
-      container_quota_items(container_quota, items)
-    end
-  end
-
-  def container_quota_scopess(parent, hashes)
-    hashes.each do |hash|
-      hash[:container_quota] = parent
-      persister.container_quota_scopes.build(hash)
-    end
-  end
-
-  def container_quota_items(parent, hashes)
-    hashes.each do |hash|
-      hash[:container_quota] = parent
-      persister.container_quota_items.build(hash)
+      parse_resource_quota(quota)
     end
   end
 
   def limit_ranges
     collector.limit_ranges.each do |data|
-      h = parse_range(data)
-
-      h[:container_project] = lazy_find_project(:name => h[:namespace])
-      items = h.delete(:container_limit_items)
-
-      limit = persister.container_limits.build(h)
-
-      limit_range_items(limit, items)
-    end
-  end
-
-  def limit_range_items(parent, hashes)
-    hashes.each do |hash|
-      hash[:container_limit] = parent
-      persister.container_limit_items.build(hash)
+      parse_range(data)
     end
   end
 
   def replication_controllers
     collector.replication_controllers.each do |rc|
-      h = parse_replication_controllers(rc)
-
-      h[:container_project] = lazy_find_project(:name => h[:namespace])
-
-      custom_attrs = h.extract!(:labels, :selector_parts)
-      tags = h.delete(:tags)
-
-      container_replicator = persister.container_replicators.build(h)
-      custom_attributes(container_replicator,
-                                  :labels    => custom_attrs[:labels],
-                                  # The actual section is "selectors"
-                                  :selectors => custom_attrs[:selector_parts])
-      taggings(container_replicator, tags)
+      parse_replication_controller(rc)
     end
   end
 
   def persistent_volume_claims
     collector.persistent_volume_claims.each do |pvc|
-      h = parse_persistent_volume_claim(pvc)
-      h[:container_project] = lazy_find_project(:name => h[:namespace])
-
-      persister.persistent_volume_claims.build(h)
+      parse_persistent_volume_claim(pvc)
     end
   end
 
   def persistent_volumes
     collector.persistent_volumes.each do |pv|
-      h = parse_persistent_volume(pv)
-
-      h.except!(:namespace) # TODO: project untested?
-
-      pvc_ref = h.delete(:persistent_volume_claim_ref)
-      h[:persistent_volume_claim] = lazy_find_persistent_volume_claim(pvc_ref)
-      persister.persistent_volumes.build(h)
+      parse_persistent_volume(pv)
     end
   end
 
   def pods
     collector.pods.each do |pod|
-      h = parse_pod(pod)
-
-      h[:container_project] = lazy_find_project(:name => h[:namespace])
-      h[:container_node] = lazy_find_node(:name => h.delete(:container_node_name))
-      h[:container_replicator] = lazy_find_replicator(h.delete(:container_replicator_ref))
-      h[:container_build_pod] = lazy_find_build_pod(:namespace => h[:namespace],
-                                                    :name      => h.delete(:build_pod_name))
-
-      custom_attrs = h.extract!(:labels, :node_selector_parts)
-      tags = h.delete(:tags)
-      children = h.extract!(:containers, :container_conditions, :container_volumes)
-
-      container_group = persister.container_groups.build(h)
-
-      containers(container_group, children[:containers])
-      container_conditions(container_group, children[:container_conditions])
-      container_volumes(container_group, children[:container_volumes])
-      custom_attributes(container_group,
-                                  :labels         => custom_attrs[:labels],
-                                  # The actual section is "node_selectors"
-                                  :node_selectors => custom_attrs[:node_selector_parts])
-      taggings(container_group, tags)
+      parse_pod(pod)
     end
   end
 
@@ -464,14 +340,14 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
   end
 
   def parse_node(node)
-    new_result = parse_base_item(node)
+    new_result = parse_base_item(node).except(:namespace)
 
     labels = parse_labels(node)
+    tags   = map_labels('ContainerNode', labels)
+
     new_result.merge!(
       :type           => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
       :identity_infra => node.spec.providerID,
-      :labels         => labels,
-      :tags           => map_labels('ContainerNode', labels),
       :lives_on_id    => nil,
       :lives_on_type  => nil
     )
@@ -491,7 +367,7 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     node_memory = parse_capacity_field("Node-Memory", node_memory)
     node_memory &&= node_memory / 1.megabyte
 
-    new_result[:computer_system] = {
+    computer_system = {
       :hardware         => {
         :cpu_total_cores => node.status.try(:capacity).try(:cpu),
         :memory_mb       => node_memory
@@ -505,10 +381,41 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     max_container_groups = node.status.try(:capacity).try(:pods)
     new_result[:max_container_groups] = parse_capacity_field("Pods", max_container_groups)
 
-    new_result[:container_conditions] = parse_conditions(node)
+    container_conditions = parse_conditions(node)
     cross_link_node(new_result)
 
-    new_result
+    container_node = persister.container_nodes.build(new_result)
+
+    container_conditions(container_node, container_conditions)
+    node_computer_systems(container_node, computer_system)
+    custom_attributes(container_node, :labels => labels)
+    taggings(container_node, tags)
+
+    container_node
+  end
+
+  def node_computer_systems(parent, hash)
+    return if hash.nil?
+
+    hash[:managed_entity] = parent
+    children = hash.extract!(:hardware, :operating_system)
+
+    computer_system = persister.computer_systems.build(hash)
+
+    node_computer_system_hardware(computer_system, children[:hardware])
+    node_computer_system_operating_system(computer_system, children[:operating_system])
+  end
+
+  def node_computer_system_hardware(parent, hash)
+    return if hash.nil?
+    hash[:computer_system] = parent
+    persister.computer_system_hardwares.build(hash)
+  end
+
+  def node_computer_system_operating_system(parent, hash)
+    return if hash.nil?
+    hash[:computer_system] = parent
+    persister.computer_system_operating_systems.build(hash)
   end
 
   def parse_service(service)
@@ -542,25 +449,28 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     new_result = parse_base_item(pod)
 
     new_result.merge!(
-      :type                => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup',
-      :restart_policy      => pod.spec.restartPolicy,
-      :dns_policy          => pod.spec.dnsPolicy,
-      :ipaddress           => pod.status.podIP,
-      :phase               => pod.status.phase,
-      :message             => pod.status.message,
-      :reason              => pod.status.reason,
-      :container_node_name => pod.spec.nodeName,
-      :containers          => [],
-      :build_pod_name      => pod.metadata.try(:annotations).try("openshift.io/build.name".to_sym)
+      :type              => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup',
+      :container_project => lazy_find_project(:name => new_result[:namespace]),
+      :restart_policy    => pod.spec.restartPolicy,
+      :dns_policy        => pod.spec.dnsPolicy,
+      :ipaddress         => pod.status.podIP,
+      :phase             => pod.status.phase,
+      :message           => pod.status.message,
+      :reason            => pod.status.reason,
+      :container_node    => lazy_find_node(:name => pod.spec.nodeName)
+    )
+
+    new_result[:container_build_pod] = lazy_find_build_pod(
+      :namespace => new_result[:namespace],
+      :name => pod.metadata.try(:annotations).try("openshift.io/build.name".to_sym)
     )
 
     # TODO, map volumes
     # TODO, podIP
     containers_index = {}
-    containers = pod.spec.containers
-    containers.each do |container_spec|
+    containers = pod.spec.containers.each_with_object([]) do |container_spec, arr|
       containers_index[container_spec.name] = parse_container_spec(container_spec, pod.metadata.uid)
-      new_result[:containers] << containers_index[container_spec.name]
+      arr << containers_index[container_spec.name]
     end
 
     unless pod.status.nil? || pod.status.containerStatuses.nil?
@@ -576,7 +486,6 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
       end
     end
 
-    new_result[:container_replicator_ref] = nil
     # NOTE: what we are trying to access here is the attribute:
     #   pod.metadata.annotations.kubernetes.io/created-by
     # but 'annotations' may be nil. The weird attribute name is
@@ -586,20 +495,30 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
       # NOTE: the annotation content is JSON, so it needs to be parsed
       createdby = JSON.parse(createdby_txt)
       if createdby.kind_of?(Hash) && !createdby['reference'].nil?
-        new_result[:container_replicator_ref] = {
+        new_result[:container_replicator] = lazy_find_replicator(
           :namespace => createdby['reference']['namespace'],
           :name      => createdby['reference']['name']
-        }
+        )
       end
     end
 
-    new_result[:container_conditions] = parse_conditions(pod)
+    container_conditions = parse_conditions(pod)
 
-    new_result[:labels] = parse_labels(pod)
-    new_result[:tags] = map_labels('ContainerGroup', new_result[:labels])
-    new_result[:node_selector_parts] = parse_node_selector_parts(pod)
-    new_result[:container_volumes] = parse_volumes(pod)
-    new_result
+    labels = parse_labels(pod)
+    tags   = map_labels('ContainerGroup', labels)
+
+    node_selector_parts = parse_node_selector_parts(pod)
+    container_volumes = parse_volumes(pod)
+
+    container_group = persister.container_groups.build(new_result)
+
+    containers(container_group, containers)
+    container_conditions(container_group, container_conditions)
+    container_volumes(container_group, container_volumes)
+    custom_attributes(container_group, :labels => labels, :node_selectors => node_selector_parts)
+    taggings(container_group, tags)
+
+    container_group
   end
 
   def parse_endpoint(entity)
@@ -621,33 +540,39 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
 
   def parse_namespace(namespace)
     new_result = parse_base_item(namespace).except(:namespace)
-    new_result[:labels] = parse_labels(namespace)
-    new_result[:tags] = map_labels('ContainerProject', new_result[:labels])
-    new_result
+
+    labels = parse_labels(namespace)
+    tags   = map_labels('ContainerProject', labels)
+
+    container_project = persister.container_projects.build(new_result)
+
+    custom_attributes(container_project, :labels => labels) # TODO: untested
+    taggings(container_project, tags)
+
+    container_project
   end
 
   def parse_persistent_volume(persistent_volume)
-    new_result = parse_base_item(persistent_volume)
+    new_result = parse_base_item(persistent_volume).except(:namespace)
     new_result.merge!(parse_volume_source(persistent_volume.spec))
     new_result.merge!(
-      :type                        => 'PersistentVolume',
-      :capacity                    => parse_resource_list(persistent_volume.spec.capacity.to_h),
-      :access_modes                => persistent_volume.spec.accessModes.join(','),
-      :reclaim_policy              => persistent_volume.spec.persistentVolumeReclaimPolicy,
-      :status_phase                => persistent_volume.status.phase,
-      :status_message              => persistent_volume.status.message,
-      :status_reason               => persistent_volume.status.reason,
-      :persistent_volume_claim_ref => nil,
+      :type           => 'PersistentVolume',
+      :capacity       => parse_resource_list(persistent_volume.spec.capacity.to_h),
+      :access_modes   => persistent_volume.spec.accessModes.join(','),
+      :reclaim_policy => persistent_volume.spec.persistentVolumeReclaimPolicy,
+      :status_phase   => persistent_volume.status.phase,
+      :status_message => persistent_volume.status.message,
+      :status_reason  => persistent_volume.status.reason
     )
 
     unless persistent_volume.spec.claimRef.nil?
-      new_result[:persistent_volume_claim_ref] = {
+      new_result[:persistent_volume_claim] = lazy_find_persistent_volume_claim(
         :namespace => persistent_volume.spec.claimRef.namespace,
         :name      => persistent_volume.spec.claimRef.name,
-      }
+      )
     end
 
-    new_result
+    persister.persistent_volumes.build(new_result)
   end
 
   def parse_resource_list(hash)
@@ -670,6 +595,7 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
   def parse_persistent_volume_claim(claim)
     new_result = parse_base_item(claim)
     new_result.merge!(
+      :container_project    => lazy_find_project(:name => new_result[:namespace]),
       :desired_access_modes => claim.spec.accessModes,
       :requests             => parse_resource_list(claim.spec.resources.requests.to_h),
       :limits               => parse_resource_list(claim.spec.resources.limits.to_h),
@@ -678,14 +604,22 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
       :capacity             => parse_resource_list(claim.status.capacity.to_h),
     )
 
-    new_result
+    persister.persistent_volume_claims.build(new_result)
   end
 
   def parse_resource_quota(resource_quota)
     new_result = parse_base_item(resource_quota)
-    new_result[:container_quota_scopes] = resource_quota.spec.scopes.to_a.collect { |scope| {:scope => scope} }
-    new_result[:container_quota_items] = parse_resource_quota_items(resource_quota)
-    new_result
+
+    scopes = resource_quota.spec.scopes.to_a.collect { |scope| {:scope => scope} }
+    items = parse_resource_quota_items(resource_quota)
+
+    new_result[:container_project] = lazy_find_project(:name => new_result[:namespace])
+    container_quota = persister.container_quotas.build(new_result)
+
+    container_quota_scopess(container_quota, scopes)
+    container_quota_items(container_quota, items)
+
+    container_quota
   end
 
   def parse_resource_quota_items(resource_quota)
@@ -713,10 +647,36 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     new_result_h.values
   end
 
+  def container_quota_scopess(parent, hashes)
+    hashes.each do |hash|
+      hash[:container_quota] = parent
+      persister.container_quota_scopes.build(hash)
+    end
+  end
+
+  def container_quota_items(parent, hashes)
+    hashes.each do |hash|
+      hash[:container_quota] = parent
+      persister.container_quota_items.build(hash)
+    end
+  end
+
   def parse_range(limit_range)
     new_result = parse_base_item(limit_range)
-    new_result[:container_limit_items] = parse_range_items limit_range
-    new_result
+    new_result[:container_project] = lazy_find_project(:name => new_result[:namespace])
+    limit = persister.container_limits.build(new_result)
+
+    items = parse_range_items(limit_range)
+    limit_range_items(limit, items)
+
+    limit
+  end
+
+  def limit_range_items(parent, hashes)
+    hashes.each do |hash|
+      hash[:container_limit] = parent
+      persister.container_limit_items.build(hash)
+    end
   end
 
   def parse_range_items(limit_range)
@@ -764,18 +724,25 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     end
   end
 
-  def parse_replication_controllers(container_replicator)
+  def parse_replication_controller(container_replicator)
     new_result = parse_base_item(container_replicator)
 
-    labels = parse_labels(container_replicator)
+    labels         = parse_labels(container_replicator)
+    tags           = map_labels('ContainerReplicator', labels)
+    selector_parts = parse_selector_parts(container_replicator)
+
     # TODO: parse template
     new_result.merge!(
       :replicas         => container_replicator.spec.replicas,
       :current_replicas => container_replicator.status.replicas,
-      :labels           => labels,
-      :tags             => map_labels('ContainerReplicator', labels),
-      :selector_parts   => parse_selector_parts(container_replicator)
+      :container_project => lazy_find_project(:name => new_result[:namespace]),
     )
+
+    container_replicator = persister.container_replicators.build(new_result)
+
+    custom_attributes(container_replicator, :labels => labels, :selectors => selector_parts)
+    taggings(container_replicator, tags)
+
     new_result
   end
 

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
@@ -1,0 +1,29 @@
+class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
+  def parse
+    parse_notices
+
+    pods
+    services
+    replication_controllers
+    nodes
+    namespaces
+    resource_quotas
+    limit_ranges
+    persistent_volumes
+    persistent_volume_claims
+  end
+
+  def parse_notices
+    collector.notices.each do |notice|
+      object = notice.object
+      kind   = object.kind
+
+      inventory_collection = persister.send(resource_by_entity(kind.underscore).tableize)
+      inventory_collection.targeted_scope << object.metadata.uid
+    end
+  end
+
+  def cgs_by_namespace_and_name
+    nil
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :ContainerManager
+  require_nested :WatchNotice
 
   def add_collection_directly(collection)
     @collections[collection.name] = collection

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/watch_notice.rb
@@ -1,0 +1,9 @@
+class ManageIQ::Providers::Kubernetes::Inventory::Persister::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
+  def targeted?
+    true
+  end
+
+  def strategy
+    :local_db_find_missing_references
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,7 +58,7 @@
 :ems_refresh:
   :kubernetes:
     :refresh_interval: 15.minutes
-    :streaming_refresh: true
+    :streaming_refresh: false
     :chunk_size: 1_000
     :inventory_collections:
       :saver_strategy: batch

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,7 +58,7 @@
 :ems_refresh:
   :kubernetes:
     :refresh_interval: 15.minutes
-    :streaming_refresh: false
+    :streaming_refresh: true
     :chunk_size: 1_000
     :inventory_collections:
       :saver_strategy: batch

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -1,645 +1,638 @@
-# instantiated at the end, for both classical and graph refresh
-shared_examples "kubernetes refresher VCR tests" do
-  before(:each) do
-    auth = AuthToken.new(:name => "test", :auth_key => "valid-token")
-    @ems = FactoryBot.create(:ems_kubernetes_with_zone, :hostname => "10.35.0.169",
-                              :ipaddress => "10.35.0.169", :port => 6443,
-                              :authentications => [auth])
-    # NOTE: the following :uid_ems should match (downcased) the kubernetes
-    #       node systemUUID in the VCR yaml file
-    @openstack_vm = FactoryBot.create(
-      :vm_openstack,
-      :uid_ems => '8b6c7070-9abd-41ac-a950-e4cfac665673')
-    @ovirt_vm = FactoryBot.create(
-      :vm_redhat,
-      :uid_ems => 'cad16607-fb88-4412-a993-5242030f6afa')
-  end
-
-  it ".ems_type" do
-    expect(described_class.ems_type).to eq(:kubernetes)
-  end
-
-  # Smoke test the use of ContainerLabelTagMapping during refresh.
-  before :each do
-    mapping = FactoryBot.create(:tag_mapping_with_category, :label_name => 'name')
-    @name_category = mapping.tag.classification
-
-    @user_tag = FactoryBot.create(:classification_cost_center_with_tags).entries.first.tag
-  end
-
-  def full_refresh_test(expected_extra_tags: [])
-    # VCR by default matches on :method and the whole :uri
-    # In this case we are sending :limit in the :query section but we
-    # want to simulate an older kube API that doesn't respond to that
-    # param.  This can be done by having VCR ignore the :query component
-    # of the URI and return the legacy style responses.
-    VCR.use_cassette(described_class.name.underscore, :match_requests_on => [:method, :host, :path]) do # , :record => :new_episodes) do
-      EmsRefresh.refresh(@ems)
-    end
-    @ems.reload
-
-    # All ems_ref fields and other auto generated fields aren't checked because the VCR file needs update
-    # every time the api changes. Until the api stabilizes, the tests on those fields are commented out.
-    assert_ems
-    assert_authentication
-    assert_table_counts
-    assert_specific_container
-    assert_specific_container_group(:expected_extra_tags => expected_extra_tags)
-    assert_specific_container_node
-    assert_specific_container_service
-    assert_specific_container_replicator(:expected_extra_tags => expected_extra_tags)
-    assert_specific_container_project
-    assert_specific_container_limit
-    assert_specific_container_image_and_registry
-    # Quotas, Volumes, PVs, and PVCs are tested in _before_deletions VCR.
-  end
-
-  it "will perform a full refresh on k8s" do
-    # Run three times to verify that second & third runs with existing data do not change anything
-    full_refresh_test
-
-    # Now records exist, simulate user assigning tags by Edit Tags, to test later refreshes don't remove them.
-    @replicator.reload.tags |= [@user_tag]
-    @containergroup.reload.tags |= [@user_tag]
-
-    full_refresh_test(:expected_extra_tags => [@user_tag])
-    full_refresh_test(:expected_extra_tags => [@user_tag])
-  end
-
-  def assert_table_counts
-    expect(ContainerGroup.count).to eq(2)
-    expect(ContainerNode.count).to eq(2)
-    expect(Container.count).to eq(3)
-    expect(ContainerService.count).to eq(5)
-    expect(ContainerPortConfig.count).to eq(2)
-    expect(ContainerEnvVar.count).to eq(3)
-    expect(ContainerReplicator.count).to eq(2)
-    expect(ContainerProject.count).to eq(1)
-    expect(ContainerQuota.count).to eq(2)
-    expect(ContainerLimit.count).to eq(3)
-    expect(ContainerImage.count).to eq(3)
-    expect(ContainerImageRegistry.count).to eq(1)
-    expect(PersistentVolume.count).to eq(1)
-  end
-
-  def assert_ems
-    expect(@ems).to have_attributes(
-      :port => 6443,
-      :type => "ManageIQ::Providers::Kubernetes::ContainerManager"
-    )
-  end
-
-  def assert_authentication
-    expect(@ems.authentication_tokens.count).to eq(1)
-    @token = @ems.authentication_tokens.last
-    expect(@token).to have_attributes(
-      :auth_key => 'valid-token'
-    )
-  end
-
-  def assert_specific_container
-    @container = Container.find_by(:name => "heapster")
-    expect(@container).to have_attributes(
-      # :ems_ref     => "a7566742-e73f-11e4-b613-001a4a5f4a02_heapster_kubernetes/heapster:v0.9",
-      :name          => "heapster",
-      :restart_count => 2,
-      :state         => "running",
-      :last_state    => "terminated",
-    # :backing_ref => "docker://87cd51044d7175c246fa1fa7699253fc2aecb769021837a966fa71e9dcb54d71"
-    )
-
-    [
-      @container.started_at,
-      @container.finished_at,
-      @container.last_started_at,
-      @container.last_finished_at,
-    ].each do |date_|
-      expect(date_.kind_of?(ActiveSupport::TimeWithZone) || date_.kind_of?(NilClass)).to be_truthy
-    end
-
-    expect(@container.container_image.name).to eq("kubernetes/heapster")
-    expect(@container.command).to eq("/heapster --source\\=kubernetes:https://kubernetes "\
-                                                      "--sink\\=influxdb:http://monitoring-influxdb:80")
-
-    @container2 = Container.find_by(:name => "influxdb")
-    expect(@container2).to have_attributes(
-      # :ems_ref       => "a7649eaa-e73f-11e4-b613-001a4a5f4a02_influxdb_kubernetes/heapster_influxdb:v0.3",
-      :name          => "influxdb",
-      :restart_count => 0,
-
-    # :backing_ref   => "docker://af741769b650a408f4a65d2d27043912b6d57e5e2a721faeb7a93a1989eef0c6"
-    )
-
-    # Check the relation to container group
-    expect(@container2.container_group).to have_attributes(
-      :name => "monitoring-influx-grafana-controller-22icy"
-    )
-
-    # Check relation to provider and container image
-    expect(@container2.container_image.name).to eq("kubernetes/heapster_influxdb")
-    expect(@container2.ext_management_system).to eq(@ems)
-
-    expect(@container.container_node).to have_attributes(
-      :name => "10.35.0.169"
-    )
-  end
-
-  def assert_specific_container_group(expected_extra_tags: [])
-    @containergroup = ContainerGroup.find_by(:name => "monitoring-heapster-controller-4j5zu")
-    expect(@containergroup).to have_attributes(
-      # :ems_ref        => "49984e80-e1b7-11e4-b7dc-001a4a5f4a02",
-      :name           => "monitoring-heapster-controller-4j5zu",
-      :restart_policy => "Always",
-      :dns_policy     => "ClusterFirst",
-      :phase          => "Running",
-    )
-    expect(@containergroup.labels).to contain_exactly(
-      label_with_name_value("name", "heapster")
-    )
-    expect(@containergroup.tags).to contain_exactly(
-      tag_in_category_with_description(@name_category, "heapster"),
-      *expected_extra_tags
-    )
-
-    # Check the relation to container node
-    expect(@containergroup.container_node).not_to be_nil
-    # @containergroup.container_node.should have_attributes(:ems_ref => "a3d2a008-e73f-11e4-b613-001a4a5f4a02")
-
-    # Check the relation to container services
-    @services = @containergroup.container_services
-    expect(@services.count).to eq(1)
-    expect(@services.first).to have_attributes(
-      # :ems_ref => "49981230-e1b7-11e4-b7dc-001a4a5f4a02",
-      :name         => "monitoring-heapster",
-      :service_type => "ClusterIP"
-    )
-
-    # Check the relation to containers
-    expect(@containergroup.containers.count).to eq(1)
-
-    # Check relations to replicator, labels and provider
-    expect(@containergroup.container_replicator).to eq(
-      ContainerReplicator.find_by(:name => "monitoring-heapster-controller")
-    )
-    expect(@containergroup.container_replicator.labels).to contain_exactly(
-      label_with_name_value("name", "heapster")
-    )
-    expect(@containergroup.ext_management_system).to eq(@ems)
-
-    # Check pod condition name is "Ready" with status "True"
-    @containergroupconditions = ContainerCondition.where(:container_entity_type => "ContainerGroup")
-    expect(@containergroupconditions.first).to have_attributes(
-      :name   => "Ready",
-      :status => "True"
-    )
-  end
-
-  def assert_specific_container_node
-    @containernode = ContainerNode.where(:name => "10.35.0.169").first
-    expect(@containernode).to have_attributes(
-      # :ems_ref       => "a3d2a008-e73f-11e4-b613-001a4a5f4a02",
-      :lives_on_type              => @openstack_vm.type,
-      :lives_on_id                => @openstack_vm.id,
-      :container_runtime_version  => "docker://1.5.0",
-      :kubernetes_kubelet_version => "v1.0.0-dirty",
-      :kubernetes_proxy_version   => "v1.0.0-dirty",
-      :max_container_groups       => 40
-    )
-
-    @containernodeconditions = ContainerCondition.where(:container_entity_type => "ContainerNode")
-    expect(@containernodeconditions.count).to eq(2)
-    expect(@containernodeconditions.first).to have_attributes(
-      :name   => "Ready",
-      :status => "True"
-    )
-
-    expect(@containernode.labels).to contain_exactly(
-      label_with_name_value("kubernetes.io/hostname", "10.35.0.169")
-    )
-
-    expect(@containernode.computer_system.operating_system).to have_attributes(
-      :distribution   => "Fedora 20 (Heisenbug)",
-      :kernel_version => "3.18.9-100.fc20.x86_64"
-    )
-
-    expect(@containernode.hardware).to have_attributes(
-      :cpu_total_cores => 2,
-      :memory_mb       => 2000
-    )
-
-    expect(@containernode.ready_condition_status).not_to be_nil
-    expect(@containernode.lives_on).to eq(@openstack_vm)
-    expect(@containernode.container_groups.count).to eq(2)
-    expect(@containernode.ext_management_system).to eq(@ems)
-
-    # Leaving this test commented out until we find a way to test this more easily
-    # Check relationship with oVirt provider
-    @containernode = ContainerNode.where(:name => "localhost.localdomain").first
-    expect(@containernode).to have_attributes(
-      :lives_on_type => @ovirt_vm.type,
-      :lives_on_id   => @ovirt_vm.id,
-    )
-    expect(@containernode.lives_on).to eq(@ovirt_vm)
-    expect(@containernode.containers.count).to eq(0)
-    expect(@containernode.container_routes.count).to eq(0)
-  end
-
-  def assert_specific_container_service
-    @containersrv = ContainerService.find_by(:name => "kubernetes")
-    expect(@containersrv).to have_attributes(
-      # :ems_ref          => "a36a2858-e73f-11e4-b613-001a4a5f4a02",
-      :name             => "kubernetes",
-      :session_affinity => "None",
-      :portal_ip        => "10.0.0.1",
-    )
-    expect(@containersrv.labels).to contain_exactly(
-      label_with_name_value("provider", "kubernetes"),
-      label_with_name_value("component", "apiserver")
-    )
-    expect(@containersrv.selector_parts.count).to eq(0)
-
-    @confs = @containersrv.container_service_port_configs
-    expect(@confs.count).to eq(1)
-    @confs = @confs.first
-    expect(@confs).to have_attributes(
-      :name        => nil,
-      :protocol    => "TCP",
-      :port        => 443,
-      :target_port => "443",
-      :node_port   => nil
-    )
-
-    # Check group relation
-    @groups = ContainerService.find_by(:name => "monitoring-influxdb-ui").container_groups
-    expect(@groups.count).to eq(1)
-    @group = @groups.first
-    expect(@group).to have_attributes(
-      # :ems_ref => "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
-      # :name    => "monitoring-influx-grafana-controller-2toua"
-      :restart_policy => "Always",
-      :dns_policy     => "ClusterFirst"
-    )
-
-    expect(@containersrv.ext_management_system).to eq(@ems)
-    expect(@containersrv.container_nodes.count).to eq(0)
-  end
-
-  def assert_specific_container_replicator(expected_extra_tags: [])
-    @replicator = ContainerReplicator.where(:name => "monitoring-influx-grafana-controller").first
-    expect(@replicator).to have_attributes(
-      :name             => "monitoring-influx-grafana-controller",
-      :replicas         => 1,
-      :current_replicas => 1
-    )
-    expect(@replicator.labels).to contain_exactly(
-      label_with_name_value("name", "influxGrafana")
-    )
-    expect(@replicator.tags).to contain_exactly(
-      tag_in_category_with_description(@name_category, "influxGrafana"),
-      *expected_extra_tags
-    )
-    expect(@replicator.selector_parts.count).to eq(1)
-
-    @group = ContainerGroup.where(:name => "monitoring-influx-grafana-controller-22icy").first
-    expect(@group.container_replicator).not_to be_nil
-    expect(@group.container_replicator.name).to eq("monitoring-influx-grafana-controller")
-    expect(@replicator.ext_management_system).to eq(@ems)
-
-    expect(@replicator.container_nodes.count).to eq(1)
-    expect(@replicator.container_nodes.first).to have_attributes(
-      :name => "10.35.0.169"
-    )
-  end
-
-  def assert_specific_container_project
-    @container_pr = ContainerProject.find_by(:name => "default")
-    expect(@container_pr).to have_attributes(
-      :name         => "default",
-      :display_name => nil
-    )
-
-    expect(@container_pr.container_groups.count).to eq(2)
-    expect(@container_pr.container_replicators.count).to eq(2)
-    expect(@container_pr.container_nodes.count).to eq(1)
-    expect(@container_pr.container_services.count).to eq(5)
-    expect(@container_pr.ext_management_system).to eq(@ems)
-  end
-
-  def assert_specific_container_quota
-    expect(ContainerQuota.where(:name => "my-resource-quota-scopes2-2").pluck(:deleted_on)).to eq([nil]) # exactly one, active.
-    container_quota = ContainerQuota.find_by(:name => "my-resource-quota-scopes2-2")
-    expect(container_quota.ems_created_on).to be_a(ActiveSupport::TimeWithZone)
-    expect(container_quota.container_quota_scopes).to contain_exactly(
-      an_object_having_attributes(:scope => "Terminating"),
-      an_object_having_attributes(:scope => "NotBestEffort"),
-    )
-    expect(container_quota.container_project.name).to eq("my-project-2")
-  end
-
-  def assert_specific_container_quota_item
-    container_quota = ContainerQuota.find_by(:name => "my-resource-quota-scopes2-2")
-    expect(container_quota.container_quota_items.count).to eq(3)
-    cpu_item = container_quota.container_quota_items.find_by(:resource => 'requests.cpu')
-    expect(cpu_item).to have_attributes(
-      :quota_desired  => 5.7,
-      :quota_enforced => 5.7,
-      :quota_observed => 0.0,
-    )
-  end
-
-  def assert_modified_container_quota_item
-    container_quota = ContainerQuota.find_by(:name => "my-resource-quota-scopes2-2")
-    expect(container_quota.container_quota_items.count).to eq(3)
-
-    cpu_items = container_quota.all_container_quota_items.where(:resource => 'requests.cpu')
-    expect(cpu_items.archived.all).to contain_exactly(
-      an_object_having_attributes(
-        :quota_desired  => 5.7,
-        :quota_enforced => 5.7,
-        :quota_observed => 0.0,
-      )
-    )
-    expect(cpu_items.active.all).to contain_exactly(
-      an_object_having_attributes(
-        :quota_desired  => 5.701,
-        :quota_enforced => 5.701,
-        :quota_observed => 0.0,
-      )
-    )
-  end
-
-  def assert_specific_container_limit
-    container_limit = ContainerLimit.find_by(:name => "limits")
-    container_limit.ems_created_on.kind_of?(ActiveSupport::TimeWithZone)
-    expect(container_limit.container_limit_items.count).to eq(2)
-    expect(container_limit.container_project.name).to eq("default")
-    item = container_limit.container_limit_items.each { |x| x[:item_type] == 'Container' && x[:resource] == 'cpu' }[0]
-    assert_specific_limit_item item
-  end
-
-  def assert_specific_limit_item(item)
-    expect(item).to have_attributes(
-      :max                     => nil,
-      :min                     => nil,
-      :default                 => "100m",
-      :default_request         => nil,
-      :max_limit_request_ratio => nil,
-    )
-  end
-
-  def assert_specific_container_image_and_registry
-    @image = ContainerImage.where(:name => "kubernetes/heapster").first
-    expect(@image).to have_attributes(
-      :name      => "kubernetes/heapster",
-      :tag       => "v0.16.0",
-      :image_ref => "docker://example.com:1234/kubernetes/heapster@f79cf2701046bea8d5f1384f7efe79dd4d20620b3594fff5be39142fa862259d",
-    )
-
-    expect(@image.container_image_registry).not_to be_nil
-    expect(@image.container_image_registry).to have_attributes(
-      :host => "example.com",
-      :port => "1234",
-    )
-    expect(@image.container_nodes.count).to eq(1)
-  end
-
-  def label_with_name_value(name, value)
-    an_object_having_attributes(
-      :section => 'labels', :source => 'kubernetes',
-      :name => name, :value => value
-    )
-  end
-
-  def tag_in_category_with_description(category, description)
-    satisfy { |tag| tag.category == category && tag.classification.description == description }
-  end
-
-  context "when refreshing an empty DB" do
-    # Recreation steps for the VCR cassettes can be found here:
-    # https://github.com/ManageIQ/manageiq-providers-openshift/blob/master/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
-
-    before(:each) do
-      VCR.use_cassette("#{described_class.name.underscore}_before_deletions",
-                       :allow_unused_http_interactions => true,
-                       :match_requests_on              => [:path,]) do # , :record => :new_episodes) do
-        EmsRefresh.refresh(@ems)
-      end
-
-      # fake node that should get archived on later refresh
-      FactoryBot.create(:container_node, :name => "node", :ems_id => @ems.id)
-    end
-
-    let(:container_volumes_count) { 68 }
-    let(:persintent_volumes_count) { 3 }
-    let(:object_counts) do
-      # using strings instead of actual model classes for compact rspec diffs
-      {
-        'ContainerNode'         => 2, # including the fake node
-        'ContainerGroup'        => 22,
-        'Container'             => 22,
-        'ContainerService'      => 16,
-        'ContainerQuota'        => 9,
-        'ContainerQuotaScope'   => 9,
-        'ContainerQuotaItem'    => 30,
-        'ContainerLimit'        => 3,
-        'ContainerLimitItem'    => 12,
-        'PersistentVolume'      => persintent_volumes_count,
-        'ContainerVolume'       => container_volumes_count + persintent_volumes_count,
-        'PersistentVolumeClaim' => 6,
-      }
-    end
-
-    it "saves the objects in the DB" do
-      actual_counts = object_counts.collect { |k, _| [k, k.constantize.count] }.to_h
-      expect(actual_counts).to eq(object_counts)
-      expect(@ems.container_volumes.count).to eq(container_volumes_count)
-      expect(@ems.persistent_volumes.count).to eq(persintent_volumes_count)
-
-      assert_specific_container_volume
-      assert_specific_persistent_volume
-      assert_specific_persistent_volume_claim
-      assert_specific_container_quota
-      assert_specific_container_quota_item
-    end
-
-    def assert_specific_container_volume
-      # Not in template but typical.  TODO: add CV to template.
-      @container_volume = ContainerVolume.find_by(:name => "my-pvc-pod-volume-2")
-      expect(@container_volume).to have_attributes(
-        :type       => "ContainerVolume",
-        :claim_name => "my-persistentvolumeclaim-2",
-      )
-      expect(@container_volume.persistent_volume_claim).to eq(
-        PersistentVolumeClaim.find_by(:name => "my-persistentvolumeclaim-2")
-      )
-      expect(@container_volume.parent_type).to eq('ContainerGroup')
-      expect(@container_volume.parent.name).to eq("my-pod-2")
-    end
-
-    def assert_specific_persistent_volume
-      # Not in template but typical.  TODO: add PV to template.
-      @persistent_volume = PersistentVolume.find_by(:name => "my-persistentvolume-2")
-      expect(@persistent_volume).to have_attributes(
-        :type           => "PersistentVolume",
-        :access_modes   => "ReadWriteOnce",
-        :capacity       => {:storage => 10.megabytes},
-        :common_path    => "/tmp/my-persistentvolume-2",
-        :reclaim_policy => "Retain",
-        :status_phase   => "Bound",
-      )
-      expect(@persistent_volume.parent).to eq(@ems)
-      expect(@persistent_volume.persistent_volume_claim.name).to eq("my-persistentvolumeclaim-2")
-
-      # through shortcuts: PV -> PVC -> CVs -> ContainerGroups
-      expect(@persistent_volume.container_volumes).to eq(
-        [ContainerVolume.find_by(:name => "my-pvc-pod-volume-2")]
-      )
-      expect(@persistent_volume.container_groups.size).to eq(1)
-      expect(@persistent_volume.container_groups[0].name).to eq("my-pod-2")
-    end
-
-    def assert_specific_persistent_volume_claim
-      # Pending PVC (in template):
-      @pending_pvc = PersistentVolumeClaim.find_by(:name => "my-persistentvolumeclaim-pending-2")
-      expect(@pending_pvc).to have_attributes(
-        :phase    => "Pending",
-        :capacity => {}, # requested 8Gi but not bound to PV => no capacity
-      )
-      expect(@pending_pvc.container_volumes.count).to eq(0)
-      expect(@pending_pvc.persistent_volume).to eq(nil)
-
-      # Bound PVC (TODO: not in template but typical):
-      @bound_pvc = PersistentVolumeClaim.find_by(:name => "my-persistentvolumeclaim-2")
-      expect(@bound_pvc).to have_attributes(
-        :phase    => "Bound",
-        :requests => {:storage => 8.megabytes},
-        :capacity => {:storage => 10.megabytes},
-      )
-      expect(@bound_pvc.container_project.name).to eq("my-project-2")
-
-      pv = PersistentVolume.find_by(:name => "my-persistentvolume-2")
-      cv = ContainerVolume.find_by(:name => "my-pvc-pod-volume-2", :type => "ContainerVolume")
-      expect(@bound_pvc.container_volumes).to contain_exactly(pv, cv)
-      expect(@bound_pvc.persistent_volume).to eq(pv)
-    end
-
-    context "when refreshing non empty DB" do
-      # After deleting resources in the cluster:
-      # "my-project-0" - The whole project
-      # "my-project-1" - All resources inside the project
-      # "my-project-2" - "my-pod-2", label of "my-route-2", parameters of "my-template-2"
-
-      before(:each) do
-        VCR.use_cassette("#{described_class.name.underscore}_after_deletions",
-                         :allow_unused_http_interactions => true,
-                         :match_requests_on              => [:path,]) do # , :record => :new_episodes) do
-          EmsRefresh.refresh(@ems)
-        end
-      end
-
-      it "removes the deleted objects from the DB" do
-        deleted = {
-          'ContainerService'      => 6,
-          'ContainerLimit'        => 2,
-          'ContainerLimitItem'    => 8,
-          'PersistentVolume'      => 0,
-          'PersistentVolumeClaim' => 4,
-        }
-        expected_counts = deleted.collect { |k, d| [k, object_counts[k] - d] }.to_h
-        actual_counts = expected_counts.collect { |k, _| [k, k.constantize.count] }.to_h
-        expect(actual_counts).to eq(expected_counts)
-
-        expect(ContainerService.find_by(:name => "my-service-0")).to be_nil
-        expect(ContainerService.find_by(:name => "my-service-1")).to be_nil
-
-        expect(ContainerLimit.find_by(:name => "my-limit-range-0")).to be_nil
-        expect(ContainerLimit.find_by(:name => "my-limit-range-1")).to be_nil
-
-        expect(PersistentVolumeClaim.find_by(:name => "my-persistentvolumeclaim-0")).to be_nil
-        expect(PersistentVolumeClaim.find_by(:name => "my-persistentvolumeclaim-1")).to be_nil
-      end
-
-      it "archives & disconnects objects" do
-        archived = {
-          'ContainerNode'  => 1, # the fake node
-          'ContainerGroup' => 2 * 2 + 1,
-          'Container'      => 2 * 2 + 1,
-          'ContainerQuota'     => 2 * 3,
-          'ContainerQuotaItem' => 2 * 10 + 2,
-        }
-        added = {
-          'ContainerQuotaItem' => 1,
-        }
-        actual_archived = archived.collect { |k, _| [k, k.constantize.archived.count] }.to_h
-        expect(actual_archived).to eq(archived)
-
-        expected_active = archived.collect { |k, a| [k, object_counts[k] - a + added.fetch(k, 0)] }.to_h
-        actual_active = archived.collect { |k, _| [k, k.constantize.active.count] }.to_h
-        expect(actual_active).to eq(expected_active)
-
-        expected_counts = archived.collect { |k, _| [k, object_counts[k] + added.fetch(k, 0)] }.to_h
-        actual_counts = archived.collect { |k, _| [k, k.constantize.count] }.to_h
-        expect(actual_counts).to eq(expected_counts)
-
-        pod0 = ContainerGroup.find_by(:name => "my-pod-0")
-        pod1 = ContainerGroup.find_by(:name => "my-pod-1")
-        pod2 = ContainerGroup.find_by(:name => "my-pod-2")
-
-        [pod0, pod1, pod2].each do |pod|
-          assert_disconnected(pod)
-          expect(pod.container_project).not_to be_nil
-          expect(pod.containers.count).to eq(1)
-          expect(pod.container_volumes.count).to eq(2) # default-token-*, my-pvc-pod-volume-2. TODO: test before deletions
-        end
-        # ContainerVolume records don't get archived themselves, but some belong to archived pods.
-        expect(ContainerVolume.where(:type => 'ContainerVolume').count).to eq(container_volumes_count)
-        expect(@ems.container_volumes.count).to eq(container_volumes_count - 18)
-
-        container0 = Container.find_by(:name => "my-container", :container_group => pod0)
-        container1 = Container.find_by(:name => "my-container", :container_group => pod1)
-        container2 = Container.find_by(:name => "my-container", :container_group => pod2)
-
-        [container0, container1, container2].each do |container|
-          expect(container).not_to be_nil
-          assert_disconnected(container)
-          expect(container.container_project).not_to be_nil
-        end
-
-        assert_specific_container_quota
-        # All items of archived quotas are archived
-        expect(ContainerQuotaItem.active.joins(:container_quota).merge(ContainerQuota.archived)).to be_empty
-        # Archived items of alive quotas:
-        archived_items = ContainerQuotaItem.archived.joins(:container_quota).merge(ContainerQuota.active)
-        expect(archived_items.pluck(:resource)).to contain_exactly(
-          'pods', # observed changed
-          'requests.cpu', # requested changed
-        )
-        assert_modified_container_quota_item
-      end
-    end
-  end
-
-  def assert_disconnected(object)
-    expect(object).not_to be_nil
-    expect(object.deleted_on).not_to be_nil
-    expect(object.archived?).to be true
-  end
-end
-
 describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
+  let!(:openstack_vm) { FactoryBot.create(:vm_openstack, :uid_ems => '8b6c7070-9abd-41ac-a950-e4cfac665673') }
+  let!(:ovirt_vm)     { FactoryBot.create(:vm_redhat,    :uid_ems => 'cad16607-fb88-4412-a993-5242030f6afa') }
+  let!(:ems) do
+    FactoryBot.create(
+      :ems_kubernetes_with_zone,
+      :hostname => "10.35.0.169",
+      :ipaddress => "10.35.0.169",
+      :port => 6443,
+      :authentications => [
+        AuthToken.new(:name => "test", :auth_key => "valid-token")
+      ]
+    )
+  end
+
   [
     {:saver_strategy => "default"},
     {:saver_strategy => "batch", :use_ar_object => true},
     {:saver_strategy => "batch", :use_ar_object => false}
   ].each do |saver_options|
     context "with #{saver_options}" do
-      before(:each) do
-        stub_settings_merge(
-          :ems_refresh => {:kubernetes => {:inventory_collections => saver_options}}
+      before(:each) { stub_settings_merge(:ems_refresh => {:kubernetes => {:inventory_collections => saver_options}}) }
+
+      it ".ems_type" do
+        expect(described_class.ems_type).to eq(:kubernetes)
+      end
+
+      # Smoke test the use of ContainerLabelTagMapping during refresh.
+      before :each do
+        mapping = FactoryBot.create(:tag_mapping_with_category, :label_name => 'name')
+        @name_category = mapping.tag.classification
+
+        @user_tag = FactoryBot.create(:classification_cost_center_with_tags).entries.first.tag
+      end
+
+      def full_refresh_test(expected_extra_tags: [])
+        full_refresh
+
+        # All ems_ref fields and other auto generated fields aren't checked because the VCR file needs update
+        # every time the api changes. Until the api stabilizes, the tests on those fields are commented out.
+        assert_ems
+        assert_authentication
+        assert_table_counts
+        assert_specific_container
+        assert_specific_container_group(:expected_extra_tags => expected_extra_tags)
+        assert_specific_container_node
+        assert_specific_container_service
+        assert_specific_container_replicator(:expected_extra_tags => expected_extra_tags)
+        assert_specific_container_project
+        assert_specific_container_limit
+        assert_specific_container_image_and_registry
+        # Quotas, Volumes, PVs, and PVCs are tested in _before_deletions VCR.
+      end
+
+      it "will perform a full refresh on k8s" do
+        # Run three times to verify that second & third runs with existing data do not change anything
+        full_refresh_test
+
+        # Now records exist, simulate user assigning tags by Edit Tags, to test later refreshes don't remove them.
+        @replicator.reload.tags |= [@user_tag]
+        @containergroup.reload.tags |= [@user_tag]
+
+        full_refresh_test(:expected_extra_tags => [@user_tag])
+        full_refresh_test(:expected_extra_tags => [@user_tag])
+      end
+
+      def assert_table_counts
+        expect(ContainerGroup.count).to eq(2)
+        expect(ContainerNode.count).to eq(2)
+        expect(Container.count).to eq(3)
+        expect(ContainerService.count).to eq(5)
+        expect(ContainerPortConfig.count).to eq(2)
+        expect(ContainerEnvVar.count).to eq(3)
+        expect(ContainerReplicator.count).to eq(2)
+        expect(ContainerProject.count).to eq(1)
+        expect(ContainerQuota.count).to eq(2)
+        expect(ContainerLimit.count).to eq(3)
+        expect(ContainerImage.count).to eq(3)
+        expect(ContainerImageRegistry.count).to eq(1)
+        expect(PersistentVolume.count).to eq(1)
+      end
+
+      def assert_ems
+        expect(ems).to have_attributes(
+          :port => 6443,
+          :type => "ManageIQ::Providers::Kubernetes::ContainerManager"
         )
       end
 
-      include_examples "kubernetes refresher VCR tests"
+      def assert_authentication
+        expect(ems.authentication_tokens.count).to eq(1)
+        token = ems.authentication_tokens.last
+        expect(token).to have_attributes(
+          :auth_key => 'valid-token'
+        )
+      end
+
+      def assert_specific_container
+        @container = Container.find_by(:name => "heapster")
+        expect(@container).to have_attributes(
+          # :ems_ref     => "a7566742-e73f-11e4-b613-001a4a5f4a02_heapster_kubernetes/heapster:v0.9",
+          :name          => "heapster",
+          :restart_count => 2,
+          :state         => "running",
+          :last_state    => "terminated"
+          # :backing_ref => "docker://87cd51044d7175c246fa1fa7699253fc2aecb769021837a966fa71e9dcb54d71"
+        )
+
+        [
+          @container.started_at,
+          @container.finished_at,
+          @container.last_started_at,
+          @container.last_finished_at,
+        ].each do |date_|
+          expect(date_.kind_of?(ActiveSupport::TimeWithZone) || date_.kind_of?(NilClass)).to be_truthy
+        end
+
+        expect(@container.container_image.name).to eq("kubernetes/heapster")
+        expect(@container.command).to eq("/heapster --source\\=kubernetes:https://kubernetes "\
+                                                          "--sink\\=influxdb:http://monitoring-influxdb:80")
+
+        @container2 = Container.find_by(:name => "influxdb")
+        expect(@container2).to have_attributes(
+          # :ems_ref       => "a7649eaa-e73f-11e4-b613-001a4a5f4a02_influxdb_kubernetes/heapster_influxdb:v0.3",
+          :name          => "influxdb",
+          :restart_count => 0
+          # :backing_ref   => "docker://af741769b650a408f4a65d2d27043912b6d57e5e2a721faeb7a93a1989eef0c6"
+        )
+
+        # Check the relation to container group
+        expect(@container2.container_group).to have_attributes(
+          :name => "monitoring-influx-grafana-controller-22icy"
+        )
+
+        # Check relation to provider and container image
+        expect(@container2.container_image.name).to eq("kubernetes/heapster_influxdb")
+        expect(@container2.ext_management_system).to eq(ems)
+
+        expect(@container.container_node).to have_attributes(
+          :name => "10.35.0.169"
+        )
+      end
+
+      def assert_specific_container_group(expected_extra_tags: [])
+        @containergroup = ContainerGroup.find_by(:name => "monitoring-heapster-controller-4j5zu")
+        expect(@containergroup).to have_attributes(
+          # :ems_ref        => "49984e80-e1b7-11e4-b7dc-001a4a5f4a02",
+          :name           => "monitoring-heapster-controller-4j5zu",
+          :restart_policy => "Always",
+          :dns_policy     => "ClusterFirst",
+          :phase          => "Running"
+        )
+        expect(@containergroup.labels).to contain_exactly(
+          label_with_name_value("name", "heapster")
+        )
+        expect(@containergroup.tags).to contain_exactly(
+          tag_in_category_with_description(@name_category, "heapster"),
+          *expected_extra_tags
+        )
+
+        # Check the relation to container node
+        expect(@containergroup.container_node).not_to be_nil
+        # @containergroup.container_node.should have_attributes(:ems_ref => "a3d2a008-e73f-11e4-b613-001a4a5f4a02")
+
+        # Check the relation to container services
+        @services = @containergroup.container_services
+        expect(@services.count).to eq(1)
+        expect(@services.first).to have_attributes(
+          # :ems_ref => "49981230-e1b7-11e4-b7dc-001a4a5f4a02",
+          :name         => "monitoring-heapster",
+          :service_type => "ClusterIP"
+        )
+
+        # Check the relation to containers
+        expect(@containergroup.containers.count).to eq(1)
+
+        # Check relations to replicator, labels and provider
+        expect(@containergroup.container_replicator).to eq(
+          ContainerReplicator.find_by(:name => "monitoring-heapster-controller")
+        )
+        expect(@containergroup.container_replicator.labels).to contain_exactly(
+          label_with_name_value("name", "heapster")
+        )
+        expect(@containergroup.ext_management_system).to eq(ems)
+
+        # Check pod condition name is "Ready" with status "True"
+        @containergroupconditions = ContainerCondition.where(:container_entity_type => "ContainerGroup")
+        expect(@containergroupconditions.first).to have_attributes(
+          :name   => "Ready",
+          :status => "True"
+        )
+      end
+
+      def assert_specific_container_node
+        @containernode = ContainerNode.where(:name => "10.35.0.169").first
+        expect(@containernode).to have_attributes(
+          # :ems_ref       => "a3d2a008-e73f-11e4-b613-001a4a5f4a02",
+          :lives_on_type              => openstack_vm.type,
+          :lives_on_id                => openstack_vm.id,
+          :container_runtime_version  => "docker://1.5.0",
+          :kubernetes_kubelet_version => "v1.0.0-dirty",
+          :kubernetes_proxy_version   => "v1.0.0-dirty",
+          :max_container_groups       => 40
+        )
+
+        @containernodeconditions = ContainerCondition.where(:container_entity_type => "ContainerNode")
+        expect(@containernodeconditions.count).to eq(2)
+        expect(@containernodeconditions.first).to have_attributes(
+          :name   => "Ready",
+          :status => "True"
+        )
+
+        expect(@containernode.labels).to contain_exactly(
+          label_with_name_value("kubernetes.io/hostname", "10.35.0.169")
+        )
+
+        expect(@containernode.computer_system.operating_system).to have_attributes(
+          :distribution   => "Fedora 20 (Heisenbug)",
+          :kernel_version => "3.18.9-100.fc20.x86_64"
+        )
+
+        expect(@containernode.hardware).to have_attributes(
+          :cpu_total_cores => 2,
+          :memory_mb       => 2000
+        )
+
+        expect(@containernode.ready_condition_status).not_to be_nil
+        expect(@containernode.lives_on).to eq(openstack_vm)
+        expect(@containernode.container_groups.count).to eq(2)
+        expect(@containernode.ext_management_system).to eq(ems)
+
+        # Leaving this test commented out until we find a way to test this more easily
+        # Check relationship with oVirt provider
+        @containernode = ContainerNode.where(:name => "localhost.localdomain").first
+        expect(@containernode).to have_attributes(
+          :lives_on_type => ovirt_vm.type,
+          :lives_on_id   => ovirt_vm.id
+        )
+        expect(@containernode.lives_on).to eq(ovirt_vm)
+        expect(@containernode.containers.count).to eq(0)
+        expect(@containernode.container_routes.count).to eq(0)
+      end
+
+      def assert_specific_container_service
+        @containersrv = ContainerService.find_by(:name => "kubernetes")
+        expect(@containersrv).to have_attributes(
+          # :ems_ref          => "a36a2858-e73f-11e4-b613-001a4a5f4a02",
+          :name             => "kubernetes",
+          :session_affinity => "None",
+          :portal_ip        => "10.0.0.1"
+        )
+        expect(@containersrv.labels).to contain_exactly(
+          label_with_name_value("provider", "kubernetes"),
+          label_with_name_value("component", "apiserver")
+        )
+        expect(@containersrv.selector_parts.count).to eq(0)
+
+        @confs = @containersrv.container_service_port_configs
+        expect(@confs.count).to eq(1)
+        @confs = @confs.first
+        expect(@confs).to have_attributes(
+          :name        => nil,
+          :protocol    => "TCP",
+          :port        => 443,
+          :target_port => "443",
+          :node_port   => nil
+        )
+
+        # Check group relation
+        @groups = ContainerService.find_by(:name => "monitoring-influxdb-ui").container_groups
+        expect(@groups.count).to eq(1)
+        @group = @groups.first
+        expect(@group).to have_attributes(
+          # :ems_ref => "49b72714-e1b7-11e4-b7dc-001a4a5f4a02",
+          # :name    => "monitoring-influx-grafana-controller-2toua"
+          :restart_policy => "Always",
+          :dns_policy     => "ClusterFirst"
+        )
+
+        expect(@containersrv.ext_management_system).to eq(ems)
+        expect(@containersrv.container_nodes.count).to eq(0)
+      end
+
+      def assert_specific_container_replicator(expected_extra_tags: [])
+        @replicator = ContainerReplicator.where(:name => "monitoring-influx-grafana-controller").first
+        expect(@replicator).to have_attributes(
+          :name             => "monitoring-influx-grafana-controller",
+          :replicas         => 1,
+          :current_replicas => 1
+        )
+        expect(@replicator.labels).to contain_exactly(
+          label_with_name_value("name", "influxGrafana")
+        )
+        expect(@replicator.tags).to contain_exactly(
+          tag_in_category_with_description(@name_category, "influxGrafana"),
+          *expected_extra_tags
+        )
+        expect(@replicator.selector_parts.count).to eq(1)
+
+        @group = ContainerGroup.where(:name => "monitoring-influx-grafana-controller-22icy").first
+        expect(@group.container_replicator).not_to be_nil
+        expect(@group.container_replicator.name).to eq("monitoring-influx-grafana-controller")
+        expect(@replicator.ext_management_system).to eq(ems)
+
+        expect(@replicator.container_nodes.count).to eq(1)
+        expect(@replicator.container_nodes.first).to have_attributes(
+          :name => "10.35.0.169"
+        )
+      end
+
+      def assert_specific_container_project
+        @container_pr = ContainerProject.find_by(:name => "default")
+        expect(@container_pr).to have_attributes(
+          :name         => "default",
+          :display_name => nil
+        )
+
+        expect(@container_pr.container_groups.count).to eq(2)
+        expect(@container_pr.container_replicators.count).to eq(2)
+        expect(@container_pr.container_nodes.count).to eq(1)
+        expect(@container_pr.container_services.count).to eq(5)
+        expect(@container_pr.ext_management_system).to eq(ems)
+      end
+
+      def assert_specific_container_quota
+        expect(ContainerQuota.where(:name => "my-resource-quota-scopes2-2").pluck(:deleted_on)).to eq([nil]) # exactly one, active.
+        container_quota = ContainerQuota.find_by(:name => "my-resource-quota-scopes2-2")
+        expect(container_quota.ems_created_on).to be_a(ActiveSupport::TimeWithZone)
+        expect(container_quota.container_quota_scopes).to contain_exactly(
+          an_object_having_attributes(:scope => "Terminating"),
+          an_object_having_attributes(:scope => "NotBestEffort")
+        )
+        expect(container_quota.container_project.name).to eq("my-project-2")
+      end
+
+      def assert_specific_container_quota_item
+        container_quota = ContainerQuota.find_by(:name => "my-resource-quota-scopes2-2")
+        expect(container_quota.container_quota_items.count).to eq(3)
+        cpu_item = container_quota.container_quota_items.find_by(:resource => 'requests.cpu')
+        expect(cpu_item).to have_attributes(
+          :quota_desired  => 5.7,
+          :quota_enforced => 5.7,
+          :quota_observed => 0.0
+        )
+      end
+
+      def assert_modified_container_quota_item
+        container_quota = ContainerQuota.find_by(:name => "my-resource-quota-scopes2-2")
+        expect(container_quota.container_quota_items.count).to eq(3)
+
+        cpu_items = container_quota.all_container_quota_items.where(:resource => 'requests.cpu')
+        expect(cpu_items.archived.all).to contain_exactly(
+          an_object_having_attributes(
+            :quota_desired  => 5.7,
+            :quota_enforced => 5.7,
+            :quota_observed => 0.0
+          )
+        )
+        expect(cpu_items.active.all).to contain_exactly(
+          an_object_having_attributes(
+            :quota_desired  => 5.701,
+            :quota_enforced => 5.701,
+            :quota_observed => 0.0
+          )
+        )
+      end
+
+      def assert_specific_container_limit
+        container_limit = ContainerLimit.find_by(:name => "limits")
+        container_limit.ems_created_on.kind_of?(ActiveSupport::TimeWithZone)
+        expect(container_limit.container_limit_items.count).to eq(2)
+        expect(container_limit.container_project.name).to eq("default")
+        item = container_limit.container_limit_items.each { |x| x[:item_type] == 'Container' && x[:resource] == 'cpu' }[0]
+        assert_specific_limit_item item
+      end
+
+      def assert_specific_limit_item(item)
+        expect(item).to have_attributes(
+          :max                     => nil,
+          :min                     => nil,
+          :default                 => "100m",
+          :default_request         => nil,
+          :max_limit_request_ratio => nil
+        )
+      end
+
+      def assert_specific_container_image_and_registry
+        @image = ContainerImage.where(:name => "kubernetes/heapster").first
+        expect(@image).to have_attributes(
+          :name      => "kubernetes/heapster",
+          :tag       => "v0.16.0",
+          :image_ref => "docker://example.com:1234/kubernetes/heapster@f79cf2701046bea8d5f1384f7efe79dd4d20620b3594fff5be39142fa862259d"
+        )
+
+        expect(@image.container_image_registry).not_to be_nil
+        expect(@image.container_image_registry).to have_attributes(
+          :host => "example.com",
+          :port => "1234"
+        )
+        expect(@image.container_nodes.count).to eq(1)
+      end
+
+      def label_with_name_value(name, value)
+        an_object_having_attributes(
+          :section => 'labels', :source => 'kubernetes',
+          :name => name, :value => value
+        )
+      end
+
+      def tag_in_category_with_description(category, description)
+        satisfy { |tag| tag.category == category && tag.classification.description == description }
+      end
+
+      context "when refreshing an empty DB" do
+        # Recreation steps for the VCR cassettes can be found here:
+        # https://github.com/ManageIQ/manageiq-providers-openshift/blob/master/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+
+        before(:each) do
+          VCR.use_cassette("#{described_class.name.underscore}_before_deletions",
+                           :allow_unused_http_interactions => true,
+                           :match_requests_on              => [:path,]) do # , :record => :new_episodes) do
+            EmsRefresh.refresh(ems)
+          end
+
+          # fake node that should get archived on later refresh
+          FactoryBot.create(:container_node, :name => "node", :ems_id => ems.id)
+        end
+
+        let(:container_volumes_count) { 68 }
+        let(:persintent_volumes_count) { 3 }
+        let(:object_counts) do
+          # using strings instead of actual model classes for compact rspec diffs
+          {
+            'ContainerNode'         => 2, # including the fake node
+            'ContainerGroup'        => 22,
+            'Container'             => 22,
+            'ContainerService'      => 16,
+            'ContainerQuota'        => 9,
+            'ContainerQuotaScope'   => 9,
+            'ContainerQuotaItem'    => 30,
+            'ContainerLimit'        => 3,
+            'ContainerLimitItem'    => 12,
+            'PersistentVolume'      => persintent_volumes_count,
+            'ContainerVolume'       => container_volumes_count + persintent_volumes_count,
+            'PersistentVolumeClaim' => 6
+          }
+        end
+
+        it "saves the objects in the DB" do
+          actual_counts = object_counts.collect { |k, _| [k, k.constantize.count] }.to_h
+          expect(actual_counts).to eq(object_counts)
+          expect(ems.container_volumes.count).to eq(container_volumes_count)
+          expect(ems.persistent_volumes.count).to eq(persintent_volumes_count)
+
+          assert_specific_container_volume
+          assert_specific_persistent_volume
+          assert_specific_persistent_volume_claim
+          assert_specific_container_quota
+          assert_specific_container_quota_item
+        end
+
+        def assert_specific_container_volume
+          # Not in template but typical.  TODO: add CV to template.
+          @container_volume = ContainerVolume.find_by(:name => "my-pvc-pod-volume-2")
+          expect(@container_volume).to have_attributes(
+            :type       => "ContainerVolume",
+            :claim_name => "my-persistentvolumeclaim-2"
+          )
+          expect(@container_volume.persistent_volume_claim).to eq(
+            PersistentVolumeClaim.find_by(:name => "my-persistentvolumeclaim-2")
+          )
+          expect(@container_volume.parent_type).to eq('ContainerGroup')
+          expect(@container_volume.parent.name).to eq("my-pod-2")
+        end
+
+        def assert_specific_persistent_volume
+          # Not in template but typical.  TODO: add PV to template.
+          @persistent_volume = PersistentVolume.find_by(:name => "my-persistentvolume-2")
+          expect(@persistent_volume).to have_attributes(
+            :type           => "PersistentVolume",
+            :access_modes   => "ReadWriteOnce",
+            :capacity       => {:storage => 10.megabytes},
+            :common_path    => "/tmp/my-persistentvolume-2",
+            :reclaim_policy => "Retain",
+            :status_phase   => "Bound"
+          )
+          expect(@persistent_volume.parent).to eq(ems)
+          expect(@persistent_volume.persistent_volume_claim.name).to eq("my-persistentvolumeclaim-2")
+
+          # through shortcuts: PV -> PVC -> CVs -> ContainerGroups
+          expect(@persistent_volume.container_volumes).to eq(
+            [ContainerVolume.find_by(:name => "my-pvc-pod-volume-2")]
+          )
+          expect(@persistent_volume.container_groups.size).to eq(1)
+          expect(@persistent_volume.container_groups[0].name).to eq("my-pod-2")
+        end
+
+        def assert_specific_persistent_volume_claim
+          # Pending PVC (in template):
+          @pending_pvc = PersistentVolumeClaim.find_by(:name => "my-persistentvolumeclaim-pending-2")
+          expect(@pending_pvc).to have_attributes(
+            :phase    => "Pending",
+            :capacity => {} # requested 8Gi but not bound to PV => no capacity
+          )
+          expect(@pending_pvc.container_volumes.count).to eq(0)
+          expect(@pending_pvc.persistent_volume).to eq(nil)
+
+          # Bound PVC (TODO: not in template but typical):
+          @bound_pvc = PersistentVolumeClaim.find_by(:name => "my-persistentvolumeclaim-2")
+          expect(@bound_pvc).to have_attributes(
+            :phase    => "Bound",
+            :requests => {:storage => 8.megabytes},
+            :capacity => {:storage => 10.megabytes}
+          )
+          expect(@bound_pvc.container_project.name).to eq("my-project-2")
+
+          pv = PersistentVolume.find_by(:name => "my-persistentvolume-2")
+          cv = ContainerVolume.find_by(:name => "my-pvc-pod-volume-2", :type => "ContainerVolume")
+          expect(@bound_pvc.container_volumes).to contain_exactly(pv, cv)
+          expect(@bound_pvc.persistent_volume).to eq(pv)
+        end
+
+        context "when refreshing non empty DB" do
+          # After deleting resources in the cluster:
+          # "my-project-0" - The whole project
+          # "my-project-1" - All resources inside the project
+          # "my-project-2" - "my-pod-2", label of "my-route-2", parameters of "my-template-2"
+
+          before(:each) do
+            VCR.use_cassette("#{described_class.name.underscore}_after_deletions",
+                             :allow_unused_http_interactions => true,
+                             :match_requests_on              => [:path,]) do # , :record => :new_episodes) do
+              EmsRefresh.refresh(ems)
+            end
+          end
+
+          it "removes the deleted objects from the DB" do
+            deleted = {
+              'ContainerService'      => 6,
+              'ContainerLimit'        => 2,
+              'ContainerLimitItem'    => 8,
+              'PersistentVolume'      => 0,
+              'PersistentVolumeClaim' => 4
+            }
+            expected_counts = deleted.collect { |k, d| [k, object_counts[k] - d] }.to_h
+            actual_counts = expected_counts.collect { |k, _| [k, k.constantize.count] }.to_h
+            expect(actual_counts).to eq(expected_counts)
+
+            expect(ContainerService.find_by(:name => "my-service-0")).to be_nil
+            expect(ContainerService.find_by(:name => "my-service-1")).to be_nil
+
+            expect(ContainerLimit.find_by(:name => "my-limit-range-0")).to be_nil
+            expect(ContainerLimit.find_by(:name => "my-limit-range-1")).to be_nil
+
+            expect(PersistentVolumeClaim.find_by(:name => "my-persistentvolumeclaim-0")).to be_nil
+            expect(PersistentVolumeClaim.find_by(:name => "my-persistentvolumeclaim-1")).to be_nil
+          end
+
+          it "archives & disconnects objects" do
+            archived = {
+              'ContainerNode'  => 1, # the fake node
+              'ContainerGroup' => 2 * 2 + 1,
+              'Container'      => 2 * 2 + 1,
+              'ContainerQuota'     => 2 * 3,
+              'ContainerQuotaItem' => 2 * 10 + 2
+            }
+            added = {
+              'ContainerQuotaItem' => 1
+            }
+            actual_archived = archived.collect { |k, _| [k, k.constantize.archived.count] }.to_h
+            expect(actual_archived).to eq(archived)
+
+            expected_active = archived.collect { |k, a| [k, object_counts[k] - a + added.fetch(k, 0)] }.to_h
+            actual_active = archived.collect { |k, _| [k, k.constantize.active.count] }.to_h
+            expect(actual_active).to eq(expected_active)
+
+            expected_counts = archived.collect { |k, _| [k, object_counts[k] + added.fetch(k, 0)] }.to_h
+            actual_counts = archived.collect { |k, _| [k, k.constantize.count] }.to_h
+            expect(actual_counts).to eq(expected_counts)
+
+            pod0 = ContainerGroup.find_by(:name => "my-pod-0")
+            pod1 = ContainerGroup.find_by(:name => "my-pod-1")
+            pod2 = ContainerGroup.find_by(:name => "my-pod-2")
+
+            [pod0, pod1, pod2].each do |pod|
+              assert_disconnected(pod)
+              expect(pod.container_project).not_to be_nil
+              expect(pod.containers.count).to eq(1)
+              expect(pod.container_volumes.count).to eq(2) # default-token-*, my-pvc-pod-volume-2. TODO: test before deletions
+            end
+            # ContainerVolume records don't get archived themselves, but some belong to archived pods.
+            expect(ContainerVolume.where(:type => 'ContainerVolume').count).to eq(container_volumes_count)
+            expect(ems.container_volumes.count).to eq(container_volumes_count - 18)
+
+            container0 = Container.find_by(:name => "my-container", :container_group => pod0)
+            container1 = Container.find_by(:name => "my-container", :container_group => pod1)
+            container2 = Container.find_by(:name => "my-container", :container_group => pod2)
+
+            [container0, container1, container2].each do |container|
+              expect(container).not_to be_nil
+              assert_disconnected(container)
+              expect(container.container_project).not_to be_nil
+            end
+
+            assert_specific_container_quota
+            # All items of archived quotas are archived
+            expect(ContainerQuotaItem.active.joins(:container_quota).merge(ContainerQuota.archived)).to be_empty
+            # Archived items of alive quotas:
+            archived_items = ContainerQuotaItem.archived.joins(:container_quota).merge(ContainerQuota.active)
+            expect(archived_items.pluck(:resource)).to contain_exactly(
+              'pods', # observed changed
+              'requests.cpu', # requested changed
+            )
+            assert_modified_container_quota_item
+          end
+        end
+      end
+
+      def assert_disconnected(object)
+        expect(object).not_to be_nil
+        expect(object.deleted_on).not_to be_nil
+        expect(object.archived?).to be true
+      end
     end
+  end
+
+  def full_refresh
+    # VCR by default matches on :method and the whole :uri
+    # In this case we are sending :limit in the :query section but we
+    # want to simulate an older kube API that doesn't respond to that
+    # param.  This can be done by having VCR ignore the :query component
+    # of the URI and return the legacy style responses.
+    VCR.use_cassette(described_class.name.underscore, :match_requests_on => [:method, :host, :path]) do # , :record => :new_episodes) do
+      EmsRefresh.refresh(ems)
+    end
+    ems.reload
   end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -1,12 +1,14 @@
 describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
+  include Spec::Support::EmsRefreshHelper
+
   let!(:openstack_vm) { FactoryBot.create(:vm_openstack, :uid_ems => '8b6c7070-9abd-41ac-a950-e4cfac665673') }
   let!(:ovirt_vm)     { FactoryBot.create(:vm_redhat,    :uid_ems => 'cad16607-fb88-4412-a993-5242030f6afa') }
   let!(:ems) do
     FactoryBot.create(
       :ems_kubernetes_with_zone,
-      :hostname => "10.35.0.169",
-      :ipaddress => "10.35.0.169",
-      :port => 6443,
+      :hostname        => "10.35.0.169",
+      :ipaddress       => "10.35.0.169",
+      :port            => 6443,
       :authentications => [
         AuthToken.new(:name => "test", :auth_key => "valid-token")
       ]
@@ -558,9 +560,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
 
           it "archives & disconnects objects" do
             archived = {
-              'ContainerNode'  => 1, # the fake node
-              'ContainerGroup' => 2 * 2 + 1,
-              'Container'      => 2 * 2 + 1,
+              'ContainerNode'      => 1, # the fake node
+              'ContainerGroup'     => 2 * 2 + 1,
+              'Container'          => 2 * 2 + 1,
               'ContainerQuota'     => 2 * 3,
               'ContainerQuotaItem' => 2 * 10 + 2
             }
@@ -609,7 +611,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
             archived_items = ContainerQuotaItem.archived.joins(:container_quota).merge(ContainerQuota.active)
             expect(archived_items.pluck(:resource)).to contain_exactly(
               'pods', # observed changed
-              'requests.cpu', # requested changed
+              'requests.cpu' # requested changed
             )
             assert_modified_container_quota_item
           end
@@ -621,6 +623,245 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
         expect(object.deleted_on).not_to be_nil
         expect(object.archived?).to be true
       end
+    end
+  end
+
+  context "Targeted refresh" do
+    before { full_refresh }
+
+    it "doesn't impact unassociated records" do
+      after_full_refresh = serialize_inventory
+
+      targeted_refresh(
+        %w[pod node namespace service limit_range persistent_volume replication_controller resource_quota].map do |type|
+          Kubeclient::Resource.new(:type => "MODIFIED", :object => load_watch_notice_data(type))
+        end
+      )
+
+      assert_inventory_not_changed(after_full_refresh, serialize_inventory)
+    end
+
+    context "limit_ranges" do
+      let(:new_limit_range) { load_watch_notice_data("new_limit_range") }
+      let(:limit_range)     { load_watch_notice_data("limit_range") }
+
+      it "created" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_limit_range)])
+        expect(ems.container_limits.pluck(:ems_ref)).to include(new_limit_range.dig(:metadata, :uid))
+      end
+
+      it "updated" do
+        limit_range[:spec][:limits][0][:default][:cpu]    = "200m"
+        limit_range[:spec][:limits][0][:default][:memory] = "1024Mi"
+
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => limit_range)])
+
+        container_limit = ems.container_limits.find_by(:ems_ref => limit_range.dig(:metadata, :uid))
+
+        cpu_limit = container_limit.container_limit_items.find_by(:resource => "cpu")
+        mem_limit = container_limit.container_limit_items.find_by(:resource => "memory")
+
+        expect(cpu_limit.default).to eq("200m")
+        expect(mem_limit.default).to eq("1024Mi")
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => limit_range)])
+        expect(ems.container_limits.pluck(:ems_ref)).not_to include(limit_range.dig(:metadata, :uid))
+      end
+    end
+
+    context "nodes" do
+      let(:new_node) { load_watch_notice_data("node") }
+      let(:node)     { load_watch_notice_data("node") }
+
+      it "created" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_node)])
+        expect(ems.container_nodes.pluck(:ems_ref)).to include(new_node.dig(:metadata, :uid))
+      end
+
+      it "updated" do
+        node[:status][:capacity][:pods] = "100"
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => node)])
+        expect(ems.container_nodes.find_by(:ems_ref => node.dig(:metadata, :uid)).max_container_groups).to eq(100)
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => node)])
+        expect(ems.container_nodes.pluck(:ems_ref)).not_to include(node.dig(:metadata, :uid))
+      end
+    end
+
+    context "persistent_volumes" do
+      let(:new_pv) { load_watch_notice_data("new_persistent_volume") }
+      let(:pv)     { load_watch_notice_data("persistent_volume") }
+
+      it "created" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_pv)])
+        expect(ems.persistent_volumes.pluck(:ems_ref)).to include(new_pv.dig(:metadata, :uid))
+      end
+
+      it "updated" do
+        pv[:spec][:capacity][:storage] = "20Gi"
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => pv)])
+        persistent_volume = ems.persistent_volumes.find_by(:ems_ref => pv.dig(:metadata, :uid))
+        expect(persistent_volume.capacity[:storage]).to eq(20.gigabytes)
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => pv)])
+        expect(ems.persistent_volumes.pluck(:ems_ref)).not_to include(pv.dig(:metadata, :uid))
+      end
+    end
+
+    context "persistent_volume_claims" do
+      let(:new_pvc) { load_watch_notice_data("new_persistent_volume_claim") }
+
+      it "created" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_pvc)])
+        expect(ems.persistent_volume_claims.pluck(:ems_ref)).to include(new_pvc.dig(:metadata, :uid))
+      end
+
+      # The VCR for full-refresh doesn't have any persistent volume claims so we
+      # have to add a new one then modify/delete it
+      it "updated" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_pvc)])
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => new_pvc)])
+        expect(ems.persistent_volume_claims.pluck(:ems_ref)).to include(new_pvc.dig(:metadata, :uid))
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_pvc)])
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => new_pvc)])
+        expect(ems.persistent_volume_claims.pluck(:ems_ref)).not_to include(new_pvc.dig(:metadata, :uid))
+      end
+    end
+
+    context "pods" do
+      let(:new_pod) { load_watch_notice_data("new_pod") }
+      let(:pod)     { load_watch_notice_data("pod") }
+
+      it "created" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_pod)])
+        expect(ems.container_groups.pluck(:ems_ref)).to include(new_pod.dig(:metadata, :uid))
+      end
+
+      it "updated" do
+        pod[:status][:phase] = "Failed"
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => pod)])
+        expect(ems.container_groups.find_by(:ems_ref => pod.dig(:metadata, :uid)).phase).to eq("Failed")
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => pod)])
+        expect(ems.container_groups.pluck(:ems_ref)).not_to include(pod.dig(:metadata, :uid))
+      end
+    end
+
+    context "projects" do
+      let(:new_namespace) { load_watch_notice_data("new_namespace") }
+      let(:namespace)     { load_watch_notice_data("namespace") }
+
+      it "created" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_namespace)])
+        expect(ems.container_projects.pluck(:ems_ref)).to include(new_namespace.dig(:metadata, :uid))
+      end
+
+      it "updated" do
+        namespace[:metadata][:name] = "my-not-as-new-project"
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => namespace)])
+        expect(ems.container_projects.pluck(:name)).to include("my-not-as-new-project")
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => namespace)])
+        expect(ems.container_projects.pluck(:ems_ref)).not_to include(namespace.dig(:metadata, :uid))
+      end
+    end
+
+    context "replication_controllers" do
+      let(:replication_controller)     { load_watch_notice_data("replication_controller") }
+      let(:new_replication_controller) { load_watch_notice_data("new_replication_controller") }
+
+      it "created" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_replication_controller)])
+        expect(ems.container_replicators.pluck(:ems_ref)).to include(new_replication_controller.dig(:metadata, :uid))
+      end
+
+      it "updated" do
+        replication_controller[:metadata][:name] = "monitoring-heapster-controller-updated"
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => replication_controller)])
+
+        container_replicator = ems.container_replicators.find_by(:ems_ref => replication_controller[:metadata][:uid])
+        expect(container_replicator.name).to eq("monitoring-heapster-controller-updated")
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => replication_controller)])
+        expect(ems.container_replicators.pluck(:ems_ref)).not_to include(replication_controller.dig(:metadata, :uid))
+      end
+    end
+
+    context "resource_quotas" do
+      let(:resource_quota)     { load_watch_notice_data("resource_quota") }
+      let(:new_resource_quota) { load_watch_notice_data("new_resource_quota") }
+
+      it "created" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_resource_quota)])
+        expect(ems.container_quotas.pluck(:ems_ref)).to include(new_resource_quota.dig(:metadata, :uid))
+      end
+
+      it "updated" do
+        resource_quota[:spec][:hard][:cpu] = "40"
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => resource_quota)])
+
+        quota = ems.container_quotas.find_by(:ems_ref => resource_quota[:metadata][:uid])
+        expect(quota.container_quota_items.first.quota_desired).to eq(40)
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => resource_quota)])
+        expect(ems.container_quotas.pluck(:ems_ref)).not_to include(resource_quota.dig(:metadata, :uid))
+      end
+    end
+
+    context "services" do
+      let(:new_service) { load_watch_notice_data("new_service") }
+      let(:service)     { load_watch_notice_data("service") }
+
+      it "created" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "ADDED", :object => new_service)])
+        expect(ems.container_services.pluck(:ems_ref)).to include(new_service.dig(:metadata, :uid))
+      end
+
+      it "updated" do
+        service[:spec][:clusterIP] = "10.0.0.116"
+        targeted_refresh([Kubeclient::Resource.new(:type => "MODIFIED", :object => service)])
+
+        container_service = ems.container_services.find_by(:ems_ref => service.dig(:metadata, :uid))
+        expect(container_service.portal_ip).to eq("10.0.0.116")
+        expect(container_service.reload.container_groups.count).to eq(1)
+      end
+
+      it "deleted" do
+        targeted_refresh([Kubeclient::Resource.new(:type => "DELETED", :object => service)])
+        expect(ems.container_services.pluck(:ems_ref)).not_to include(service.dig(:metadata, :uid))
+      end
+    end
+
+    def targeted_refresh(notices)
+      collector = ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice.new(ems, notices)
+      persister = ManageIQ::Providers::Kubernetes::Inventory::Persister::WatchNotice.new(ems, nil)
+      parser    = ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice.new
+
+      parser.collector = collector
+      parser.persister = persister
+      parser.parse
+      persister.persist!
+    end
+
+    def load_watch_notice_data(type)
+      YAML.load_file("spec/models/manageiq/providers/kubernetes/container_manager/watches_data/#{type}.yml")
     end
   end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/endpoint.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/endpoint.yml
@@ -1,0 +1,25 @@
+---
+:metadata:
+  :name: monitoring-grafana
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/endpoints/monitoring-grafana"
+  :uid: 1f3049d8-35f2-11e5-8917-001a4a5f4a00
+  :resourceVersion: '197'
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :kubernetes.io/cluster-service: 'true'
+    :kubernetes.io/name: monitoring-grafana
+:subsets:
+- :addresses:
+  - :ip: 172.17.0.2
+    :targetRef:
+      :kind: Pod
+      :namespace: default
+      :name: monitoring-influx-grafana-controller-22icy
+      :uid: 1f60be5d-35f2-11e5-8917-001a4a5f4a00
+      :resourceVersion: '194'
+  :ports:
+  - :port: 8080
+    :protocol: TCP
+:kind: Endpoint
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/limit_range.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/limit_range.yml
@@ -1,0 +1,16 @@
+---
+:metadata:
+  :name: limits
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/limitranges/limits"
+  :uid: '081e3eb8-4035-11e5-b186-0aaeec44370e'
+  :resourceVersion: '497'
+  :creationTimestamp: '2015-08-11T14:27:01Z'
+:spec:
+  :limits:
+  - :type: Container
+    :default:
+      :cpu: 100m
+      :memory: 512Mi
+:kind: LimitRange
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/namespace.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/namespace.yml
@@ -1,0 +1,14 @@
+---
+:metadata:
+  :name: default
+  :selfLink: "/api/v1/namespaces/default"
+  :uid: 665eae8f-35f0-11e5-8917-001a4a5f4a00
+  :resourceVersion: '6'
+  :creationTimestamp: '2015-07-29T12:50:33Z'
+:spec:
+  :finalizers:
+  - kubernetes
+:status:
+  :phase: Active
+:kind: Namespace
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_limit_range.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_limit_range.yml
@@ -1,0 +1,16 @@
+---
+:metadata:
+  :name: limits4
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/limitranges/limits4"
+  :uid: 748b15c8-1dfc-4099-ab16-69395f232087
+  :resourceVersion: '497'
+  :creationTimestamp: '2015-08-11T14:27:01Z'
+:spec:
+  :limits:
+  - :type: Container
+    :default:
+      :cpu: 100m
+      :memory: 512Mi
+:kind: LimitRange
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_namespace.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_namespace.yml
@@ -1,0 +1,8 @@
+---
+:kind: Namespace
+:apiVersion: v1
+:metadata:
+  :name: my-new-project
+  :selfLink: "/api/v1/namespaces/my-new-project"
+  :uid: 9d5d61ed-b861-4140-9e64-8efc7048d10d
+  :resourceVersion: '750378'

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_node.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_node.yml
@@ -1,0 +1,36 @@
+---
+:metadata:
+  :name: 10.35.0.170
+  :selfLink: "/api/v1/nodes/10.35.0.170"
+  :uid: a4a9b6ec-4f11-4c0a-9fd9-043b51ed26d1
+  :resourceVersion: '5302'
+  :creationTimestamp: '2015-07-29T12:50:46Z'
+  :labels:
+    :kubernetes.io/hostname: 10.35.0.170
+:spec:
+  :externalID: 10.35.0.170
+:status:
+  :capacity:
+    :cpu: '2'
+    :memory: 2048080Ki
+    :pods: '40'
+  :conditions:
+  - :type: Ready
+    :status: 'True'
+    :lastHeartbeatTime: '2015-07-29T15:53:24Z'
+    :lastTransitionTime: '2015-07-29T12:50:46Z'
+    :reason: kubelet is posting ready status
+  :addresses:
+  - :type: LegacyHostIP
+    :address: 10.35.0.170
+  :nodeInfo:
+    :machineID: 8b6c70709abd41aca950e4cfad665673
+    :systemUUID: 8B6C7070-9ABD-41AC-A951-E4CFAC665673
+    :bootID: da9a3173-328f-4bd6-a423-17189d74e3a4
+    :kernelVersion: 3.18.9-100.fc20.x86_64
+    :osImage: Fedora 20 (Heisenbug)
+    :containerRuntimeVersion: docker://1.5.0
+    :kubeletVersion: v1.0.0-dirty
+    :kubeProxyVersion: v1.0.0-dirty
+:kind: Node
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_persistent_volume.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_persistent_volume.yml
@@ -1,0 +1,20 @@
+:metadata:
+  :name: pv0002
+  :selfLink: "/api/v1/persistentvolumes/pv0002"
+  :uid: 8503e3f6-b3b0-44cd-bedc-325fb497c7c3
+  :resourceVersion: '380779'
+  :creationTimestamp: '2015-08-24T14:21:43Z'
+  :labels:
+    :type: local
+:spec:
+  :capacity:
+    :storage: 20Gi
+  :hostPath:
+    :path: "/tmp/data02"
+  :accessModes:
+  - ReadWriteOnce
+  :persistentVolumeReclaimPolicy: Retain
+:status:
+  :phase: Available
+:kind: PersistentVolume
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_persistent_volume_claim.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_persistent_volume_claim.yml
@@ -1,0 +1,32 @@
+---
+:metadata:
+  :name: my-persistentvolumeclaim-0
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/persistentvolumeclaims/my-persistentvolumeclaim-0"
+  :uid: 9b0629a3-dadf-11e9-86a6-525400b7d5c1
+  :resourceVersion: '10335'
+  :creationTimestamp: '2019-09-19T13:15:52Z'
+  :annotations:
+    :pv.kubernetes.io/bind-completed: 'yes'
+    :pv.kubernetes.io/bound-by-controller: 'yes'
+  :finalizers:
+  - kubernetes.io/pvc-protection
+:spec:
+  :accessModes:
+  - ReadWriteOnce
+  :selector:
+    :matchLabels:
+      :my-pv-label: my-pv-0
+  :resources:
+    :requests:
+      :storage: 8Mi
+  :volumeName: my-persistentvolume-0
+  :storageClassName: manual
+:status:
+  :phase: Bound
+  :accessModes:
+  - ReadWriteOnce
+  :capacity:
+    :storage: 10Mi
+:kind: PersistentVolumeClaim
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_pod.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_pod.yml
@@ -1,0 +1,62 @@
+---
+:kind: Pod
+:apiVersion: v1
+:metadata:
+  :name: new-pod-4k5zu
+  :generateName: new-pod-
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/pods/new-pod-4k5zu"
+  :uid: 46cd0de6-7cf6-461b-8595-803b0e565dc0
+  :resourceVersion: '5253'
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :name: heapster
+  :annotations:
+    :kubernetes.io/created-by: '{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"default","name":"monitoring-heapster-controller","uid":"1f2d2157-35f2-11e5-8917-001a4a5f4a00","apiVersion":"v1","resourceVersion":"100"}}'
+:spec:
+  :volumes:
+  - :name: default-token-a2ui3
+    :secret:
+      :secretName: default-token-a2ui3
+  :containers:
+  - :name: heapster
+    :image: example.com:1234/kubernetes/heapster:v0.16.0
+    :command:
+    - "/heapster"
+    - "--source=kubernetes:https://kubernetes"
+    - "--sink=influxdb:http://monitoring-influxdb:80"
+    :resources: {}
+    :volumeMounts:
+    - :name: default-token-a2ui3
+      :readOnly: true
+      :mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+    :terminationMessagePath: "/dev/termination-log"
+    :imagePullPolicy: IfNotPresent
+  :restartPolicy: Always
+  :dnsPolicy: ClusterFirst
+  :serviceAccountName: default
+  :nodeName: 10.35.0.169
+:status:
+  :phase: Running
+  :conditions:
+  - :type: Ready
+    :status: 'True'
+  :hostIP: 10.35.0.169
+  :podIP: 172.17.0.4
+  :startTime: '2015-07-29T13:02:53Z'
+  :containerStatuses:
+  - :name: heapster
+    :state:
+      :running:
+        :startedAt: '2015-07-29T15:49:04Z'
+    :lastState:
+      :terminated:
+        :exitCode: 1
+        :startedAt: '2015-07-29T15:48:42Z'
+        :finishedAt: '2015-07-29T15:48:42Z'
+        :containerID: docker://7780ef155c1d87a3f8a36a6ad5a6a3e25cdc4f9c90693276c32c924ca603382d
+    :ready: true
+    :restartCount: 2
+    :image: example.com:1234/kubernetes/heapster:v0.16.0
+    :imageID: docker://f79cf2701046bea8d5f1384f7efe79dd4d20620b3594fff5be39142fa862259d
+    :containerID: docker://2baa337fef20ab18c5cae16937fca0b4a59ccbb5ecac1f89ad7898a02d74e3c9

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_replication_controller.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_replication_controller.yml
@@ -1,0 +1,38 @@
+---
+:metadata:
+  :name: new-monitoring-heapster-controller
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/replicationcontrollers/monitoring-heapster-controller"
+  :uid: 66eddb27-7f75-43f6-aafc-425c4aac9e63
+  :resourceVersion: '122'
+  :generation: 1
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :name: heapster
+:spec:
+  :replicas: 1
+  :selector:
+    :name: heapster
+  :template:
+    :metadata:
+      :creationTimestamp:
+      :labels:
+        :name: heapster
+    :spec:
+      :containers:
+      - :name: heapster
+        :image: kubernetes/heapster:v0.16.0
+        :command:
+        - "/heapster"
+        - "--source=kubernetes:https://kubernetes"
+        - "--sink=influxdb:http://monitoring-influxdb:80"
+        :resources: {}
+        :terminationMessagePath: "/dev/termination-log"
+        :imagePullPolicy: IfNotPresent
+      :restartPolicy: Always
+      :dnsPolicy: ClusterFirst
+:status:
+  :replicas: 1
+  :observedGeneration: 1
+:kind: ReplicationController
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_resource_quota.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_resource_quota.yml
@@ -1,0 +1,17 @@
+:metadata:
+  :name: quota3
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/resourcequotas/quota3"
+  :uid: c282c024-0fbd-485d-ae63-5f64489aaec6
+  :resourceVersion: '165339'
+  :creationTimestamp: '2015-08-17T09:16:46Z'
+:spec:
+  :hard:
+    :cpu: '30'
+:status:
+  :hard:
+    :cpu: '30'
+  :used:
+    :cpu: 100m
+:kind: ResourceQuota
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_service.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/new_service.yml
@@ -1,0 +1,26 @@
+---
+:metadata:
+  :name: monitoring-grafana-2
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/services/monitoring-grafana-2"
+  :uid: 41ebdba8-4aed-4f4c-a588-84945a672cfe
+  :resourceVersion: '99'
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :kubernetes.io/cluster-service: 'true'
+    :kubernetes.io/name: monitoring-grafana-2
+:spec:
+  :ports:
+  - :protocol: TCP
+    :port: 80
+    :targetPort: 8080
+    :nodePort: 0
+  :selector:
+    :name: influxGrafana
+  :clusterIP: 10.0.0.115
+  :type: ClusterIP
+  :sessionAffinity: None
+:status:
+  :loadBalancer: {}
+:kind: Service
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/node.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/node.yml
@@ -1,0 +1,36 @@
+---
+:metadata:
+  :name: 10.35.0.169
+  :selfLink: "/api/v1/nodes/10.35.0.169"
+  :uid: 6de77025-35f0-11e5-8917-001a4a5f4a00
+  :resourceVersion: '5302'
+  :creationTimestamp: '2015-07-29T12:50:45Z'
+  :labels:
+    :kubernetes.io/hostname: 10.35.0.169
+:spec:
+  :externalID: 10.35.0.169
+:status:
+  :capacity:
+    :cpu: '2'
+    :memory: 2048080Ki
+    :pods: '40'
+  :conditions:
+  - :type: Ready
+    :status: 'True'
+    :lastHeartbeatTime: '2015-07-29T15:53:23Z'
+    :lastTransitionTime: '2015-07-29T12:50:45Z'
+    :reason: kubelet is posting ready status
+  :addresses:
+  - :type: LegacyHostIP
+    :address: 10.35.0.169
+  :nodeInfo:
+    :machineID: 8b6c70709abd41aca950e4cfac665673
+    :systemUUID: 8B6C7070-9ABD-41AC-A950-E4CFAC665673
+    :bootID: da9a3173-328f-4bd6-a422-17189d74e3a4
+    :kernelVersion: 3.18.9-100.fc20.x86_64
+    :osImage: Fedora 20 (Heisenbug)
+    :containerRuntimeVersion: docker://1.5.0
+    :kubeletVersion: v1.0.0-dirty
+    :kubeProxyVersion: v1.0.0-dirty
+:kind: Node
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/persistent_volume.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/persistent_volume.yml
@@ -1,0 +1,20 @@
+:metadata:
+  :name: pv0001
+  :selfLink: "/api/v1/persistentvolumes/pv0001"
+  :uid: 71e4aa67-4a6b-11e5-b186-0aaeec44370e
+  :resourceVersion: '380779'
+  :creationTimestamp: '2015-08-24T14:21:43Z'
+  :labels:
+    :type: local
+:spec:
+  :capacity:
+    :storage: 10Gi
+  :hostPath:
+    :path: "/tmp/data01"
+  :accessModes:
+  - ReadWriteOnce
+  :persistentVolumeReclaimPolicy: Retain
+:status:
+  :phase: Available
+:kind: PersistentVolume
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/pod.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/pod.yml
@@ -1,0 +1,62 @@
+---
+:metadata:
+  :name: monitoring-heapster-controller-4j5zu
+  :generateName: monitoring-heapster-controller-
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/pods/monitoring-heapster-controller-4j5zu"
+  :uid: 1f60bc7c-35f2-11e5-8917-001a4a5f4a00
+  :resourceVersion: '5253'
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :name: heapster
+  :annotations:
+    :kubernetes.io/created-by: '{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"default","name":"monitoring-heapster-controller","uid":"1f2d2157-35f2-11e5-8917-001a4a5f4a00","apiVersion":"v1","resourceVersion":"100"}}'
+:spec:
+  :volumes:
+  - :name: default-token-a2ui3
+    :secret:
+      :secretName: default-token-a2ui3
+  :containers:
+  - :name: heapster
+    :image: example.com:1234/kubernetes/heapster:v0.16.0
+    :command:
+    - "/heapster"
+    - "--source=kubernetes:https://kubernetes"
+    - "--sink=influxdb:http://monitoring-influxdb:80"
+    :resources: {}
+    :volumeMounts:
+    - :name: default-token-a2ui3
+      :readOnly: true
+      :mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+    :terminationMessagePath: "/dev/termination-log"
+    :imagePullPolicy: IfNotPresent
+  :restartPolicy: Always
+  :dnsPolicy: ClusterFirst
+  :serviceAccountName: default
+  :nodeName: 10.35.0.169
+:status:
+  :phase: Running
+  :conditions:
+  - :type: Ready
+    :status: 'True'
+  :hostIP: 10.35.0.169
+  :podIP: 172.17.0.3
+  :startTime: '2015-07-29T13:02:53Z'
+  :containerStatuses:
+  - :name: heapster
+    :state:
+      :running:
+        :startedAt: '2015-07-29T15:49:04Z'
+    :lastState:
+      :terminated:
+        :exitCode: 1
+        :startedAt: '2015-07-29T15:48:42Z'
+        :finishedAt: '2015-07-29T15:48:42Z'
+        :containerID: docker://7780ef155c1d87a3f8a36a6ad5a6a3e25cdc4f9c90693276c32c924ca603382d
+    :ready: true
+    :restartCount: 2
+    :image: example.com:1234/kubernetes/heapster:v0.16.0
+    :imageID: docker://f79cf2701046bea8d5f1384f7efe79dd4d20620b3594fff5be39142fa862259d
+    :containerID: docker://2baa337fef20ab18c5cae16937fca0b4a59ccbb5ecac1f89ad7898a02d74e3c9
+:kind: Pod
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/replication_controller.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/replication_controller.yml
@@ -1,0 +1,38 @@
+---
+:metadata:
+  :name: monitoring-heapster-controller
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/replicationcontrollers/monitoring-heapster-controller"
+  :uid: 1f2d2157-35f2-11e5-8917-001a4a5f4a00
+  :resourceVersion: '122'
+  :generation: 1
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :name: heapster
+:spec:
+  :replicas: 1
+  :selector:
+    :name: heapster
+  :template:
+    :metadata:
+      :creationTimestamp:
+      :labels:
+        :name: heapster
+    :spec:
+      :containers:
+      - :name: heapster
+        :image: kubernetes/heapster:v0.16.0
+        :command:
+        - "/heapster"
+        - "--source=kubernetes:https://kubernetes"
+        - "--sink=influxdb:http://monitoring-influxdb:80"
+        :resources: {}
+        :terminationMessagePath: "/dev/termination-log"
+        :imagePullPolicy: IfNotPresent
+      :restartPolicy: Always
+      :dnsPolicy: ClusterFirst
+:status:
+  :replicas: 1
+  :observedGeneration: 1
+:kind: ReplicationController
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/resource_quota.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/resource_quota.yml
@@ -1,0 +1,17 @@
+:metadata:
+  :name: quota2
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/resourcequotas/quota2"
+  :uid: af3d1a10-44c0-11e5-b186-0aaeec44370e
+  :resourceVersion: '165339'
+  :creationTimestamp: '2015-08-17T09:16:46Z'
+:spec:
+  :hard:
+    :cpu: '30'
+:status:
+  :hard:
+    :cpu: '30'
+  :used:
+    :cpu: 100m
+:kind: ResourceQuota
+:apiVersion: v1

--- a/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/service.yml
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/watches_data/service.yml
@@ -1,0 +1,26 @@
+---
+:metadata:
+  :name: monitoring-grafana
+  :namespace: default
+  :selfLink: "/api/v1/namespaces/default/services/monitoring-grafana"
+  :uid: 1f1b4bc0-35f2-11e5-8917-001a4a5f4a00
+  :resourceVersion: '99'
+  :creationTimestamp: '2015-07-29T13:02:52Z'
+  :labels:
+    :kubernetes.io/cluster-service: 'true'
+    :kubernetes.io/name: monitoring-grafana
+:spec:
+  :ports:
+  - :protocol: TCP
+    :port: 80
+    :targetPort: 8080
+    :nodePort: 0
+  :selector:
+    :name: influxGrafana
+  :clusterIP: 10.0.0.115
+  :type: ClusterIP
+  :sessionAffinity: None
+:status:
+  :loadBalancer: {}
+:kind: Service
+:apiVersion: v1


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/366 and dependent PRs https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/370 and https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/371 with the addition of https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/374/commits/a11a3a86f3600411126017c7775eb15470b57385 to disable streaming refresh by default for backport.

Depends on https://github.com/ManageIQ/manageiq/pull/20098 being backported