### PR TITLE
Add parser methods for entity manager_refs

### DIFF
--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -926,6 +926,14 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     }
   end
 
+  def parse_default_manager_ref(obj)
+    obj.metadata.uid
+  end
+
+  %w[pod service replication_controller node namespace resource_quota limit_range persistent_volume persistent_volume_claim].each do |kind|
+    alias_method :"parse_#{kind}_manager_ref", :parse_default_manager_ref
+  end
+
   def parse_image_name(image, image_ref)
     # parsing using same logic as in docker
     # https://github.com/docker/docker/blob/348f6529b71502b561aa493e250fd5be248da0d5/reference/reference.go#L174

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/watch_notice.rb
@@ -21,8 +21,11 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ
       collection_name = resource_by_entity(kind.underscore)
       next if collection_name.nil?
 
+      manager_ref = send("parse_#{kind.underscore}_manager_ref", object)
+      next if manager_ref.nil?
+
       inventory_collection = persister.send(resource_by_entity(kind.underscore).tableize)
-      inventory_collection.targeted_scope << object.metadata.uid
+      inventory_collection.targeted_scope << manager_ref
     end
   end
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister.rb
@@ -5,12 +5,4 @@ class ManageIQ::Providers::Kubernetes::Inventory::Persister < ManageIQ::Provider
   def add_collection_directly(collection)
     @collections[collection.name] = collection
   end
-
-  # ManageIQ::Providers::InventoryCollection.inventory_object_attributes
-  # are not defined
-  def make_builder_settings(extra_settings = {})
-    opts = super
-    opts[:auto_inventory_attributes] = false
-    opts
-  end
 end


### PR DESCRIPTION
Not all entity types use metadata.uid as the manager ref (e.g. OpenShift BuildPods use [name, namespace]).

Needed for: https://github.com/ManageIQ/manageiq-providers-openshift/pull/169