### PR TITLE
Update kubeclient to v4.6

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("hawkular-client",                 "~> 4.1")
   s.add_runtime_dependency("image-inspector-client",          "~> 2.0")
-  s.add_runtime_dependency("kubeclient",                      "~> 4.3")
+  s.add_runtime_dependency("kubeclient",                      "~> 4.6")
   s.add_runtime_dependency("prometheus-alert-buffer-client",  "~> 0.2.0")
   s.add_runtime_dependency("prometheus-api-client",           "~> 0.6")
   s.add_runtime_dependency("more_core_extensions",            "~> 3.6")


### PR DESCRIPTION
Bump kubeclient to version 4.6.  Besides just staying up-to-date this ensures that we can use k8s watches with ruby 2.7 (see https://github.com/abonas/kubeclient/issues/442)

https://github.com/ManageIQ/manageiq/issues/19678