### PR TITLE
We moved capture_container_targets out of Metric::Target

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -382,15 +382,6 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   end
 
   def queue_metrics_capture
-    targets = Metric::Targets.capture_container_targets([self], {})
-
-    targets.each do |target|
-      begin
-        target.perf_capture_queue('realtime', :priority => MiqQueue::HIGH_PRIORITY)
-      rescue StandardError => err
-        _log.error("Failed to queue perf_capture for target [#{target.class.name}], [#{target.id}], [#{target.name}]: #{err}")
-        raise
-      end
-    end
+    self.perf_capture_object.perf_capture_all_queue
   end
 end


### PR DESCRIPTION
Some recent refactoring caused the ContainerManager#queue_metrics_capture call to start failing.