### PR TITLE
[JANSA] Jansa doesn't have perf_capture_all_queue

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -382,6 +382,6 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   end
 
   def queue_metrics_capture
-    self.perf_capture_object.perf_capture_all_queue
+    self.perf_capture_object.perf_capture
   end
 end


### PR DESCRIPTION
The perf_capture_all_queue method was added in https://github.com/ManageIQ/manageiq/pull/19934 and is not on jansa.

Followup to https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/380