### PR TITLE
bump more core extension dependency

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("hawkular-client",                 "~> 4.1")
   s.add_runtime_dependency("image-inspector-client",          "~> 2.0")
   s.add_runtime_dependency("kubeclient",                      "~> 4.6")
+  s.add_runtime_dependency("more_core_extensions",            ">= 3.6", "< 5")
   s.add_runtime_dependency("prometheus-alert-buffer-client",  "~> 0.2.0")
   s.add_runtime_dependency("prometheus-api-client",           "~> 0.6")
-  s.add_runtime_dependency("more_core_extensions",            "~> 3.6")
 
   s.add_development_dependency("codeclimate-test-reporter", "~> 1.0.0")
   s.add_development_dependency("recursive-open-struct",     "~> 1.0.0")


### PR DESCRIPTION
more core ext's on 4.1.0

update for update sake

https://github.com/ManageIQ/more_core_extensions/compare/179bf40..e5b4501
 - Added Ruby 2.7 support [[#79](https://github.com/ManageIQ/more_core_extensions/pull/79)]
 - Added Process#pause, Process#resume, and Process#alive? [[#73](https://github.com/ManageIQ/more_core_extensions/pull/73)]

array added * `#compact_map` - Collect non-nil results from the block
array added `#tabular_sort` - Sorts an Array of Hashes by specific columns

hierarchy added `#descendant_get` - Returns the descendant with a given name

the two breaking changes:
- **BREAKING**: Moved Object#descendant_get to Class#descendant_get [[#75](https://github.com/ManageIQ/more_core_extensions/pull/75)]
- **BREAKING**: Removed deprecated Enumerable#stable_sort_by [[#76](https://github.com/ManageIQ/more_core_extensions/pull/76)]

a minor header output change was made that hasn't been released yet to make tableize more markdown compliant

see https://github.com/ManageIQ/linux_admin/pull/221