### PR TITLE
Fix node network metrics with ens.* interfaces

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
@@ -67,8 +67,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
       # prometheus field is in bytes
       # miq field is on kb ( / 1000 )
       if @metrics.include?('net_usage_rate_average')
-        net_resid = "sum(rate(container_network_receive_bytes_total{#{labels},interface=~\"eth.*\"}[#{AVG_OVER}])) + " \
-                    "sum(rate(container_network_transmit_bytes_total{#{labels},interface=~\"eth.*\"}[#{AVG_OVER}]))"
+        interfaces = "eth.*|ens.*|enp.*|eno.*"
+        net_resid = "sum(rate(container_network_receive_bytes_total{#{labels},interface=~\"#{interfaces}\"}[#{AVG_OVER}])) + " \
+                    "sum(rate(container_network_transmit_bytes_total{#{labels},interface=~\"#{interfaces}\"}[#{AVG_OVER}]))"
         fetch_counters_data(net_resid, 'net_usage_rate_average', 1000.0)
       end
 

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_node_metrics.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_node_metrics.yml
@@ -82,7 +82,7 @@ http_interactions:
   recorded_at: Thu, 04 Jun 2020 20:10:12 GMT
 - request:
     method: get
-    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%22%7D%5B2m%5D))&start=1591300740&step=60s
+    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))&start=1591300740&step=60s
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_node_timespan.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_node_timespan.yml
@@ -82,7 +82,7 @@ http_interactions:
   recorded_at: Thu, 04 Jun 2020 20:11:43 GMT
 - request:
     method: get
-    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%22%7D%5B2m%5D))&start=1591300740&step=60s
+    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))&start=1591300740&step=60s
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_pod_metrics.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_pod_metrics.yml
@@ -82,7 +82,7 @@ http_interactions:
   recorded_at: Thu, 04 Jun 2020 20:10:13 GMT
 - request:
     method: get
-    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%22%7D%5B2m%5D))&start=1591300740&step=60s
+    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))&start=1591300740&step=60s
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_pod_timespan.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_pod_timespan.yml
@@ -82,7 +82,7 @@ http_interactions:
   recorded_at: Thu, 04 Jun 2020 20:11:43 GMT
 - request:
     method: get
-    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%22%7D%5B2m%5D))&start=1591300740&step=60s
+    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))&start=1591300740&step=60s
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
If the container node network interfaces are named e.g. ens0 instead of eth0 the query for network metrics fails causing no node metrics to be saved.

According to the Linux Consistent Network Device Naming conventions [ref](https://en.wikipedia.org/wiki/Consistent_Network_Device_Naming) ifaces can be `eth[0..N]`, `eno[1..N]`, `ens[1..N]`, or `enp<PCI Slot>s<Card Number>`.

Example prometheus query with the newer interface naming:
![Screenshot from 2020-06-30 12-16-03](https://user-images.githubusercontent.com/12851112/86151327-968ae080-bacc-11ea-92db-10f2a6f3cca9.png)
