### PR TITLE
Fix "private method 'watch' called for WatchThread"

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
@@ -31,10 +31,13 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::WatchThr
     thread&.join(join_limit)
   end
 
+  protected
+
+  attr_accessor :resource_version, :thread, :watch
+
   private
 
   attr_reader :connect_options, :ems_klass, :entity_type, :finish, :queue
-  attr_accessor :resource_version, :thread, :watch
 
   def collector_thread
     _log.debug { "Starting watch thread for #{entity_type}" }


### PR DESCRIPTION
Starting the watch threads assigns the watch thread to a self.thread instance variable, this is throwing a private method exception on older rubies (I don't see this on 2.7)

```
ERROR -- : [NoMethodError]: private method 'watch' called for #<ManageIQ::Providers::Openshift::ContainerManager::RefreshWorker::WatchThread:0x0000558b852f8af8>
ERROR -- : app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb:43:in 'collector_thread'
app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb:23:in 'block in start!'
```

This isn't the default on jansa so it isn't critical to be backported, but a user could change the settings and enable it.