### PR TITLE
PERF_ROLLUP_CHILDREN should be an Array

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -161,7 +161,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     end
   end
 
-  PERF_ROLLUP_CHILDREN = :container_nodes
+  PERF_ROLLUP_CHILDREN = [:container_nodes]
 
   def verify_hawkular_credentials
     client = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::HawkularClient.new(self)


### PR DESCRIPTION
The only callers then call `#to_miq_a`

https://github.com/ManageIQ/manageiq/blob/33d994ae207105a508d9e214d39d9ec66ac066dd/app/models/metric/rollup.rb#L189
https://github.com/ManageIQ/manageiq/blob/33d994ae207105a508d9e214d39d9ec66ac066dd/app/models/metric/rollup.rb#L204