### PR TITLE
Bump the Prometheus Alert Buffer Client gem

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("image-inspector-client",          "~> 2.0")
   s.add_runtime_dependency("kubeclient",                      "~> 4.6")
   s.add_runtime_dependency("more_core_extensions",            ">= 3.6", "< 5")
-  s.add_runtime_dependency("prometheus-alert-buffer-client",  "~> 0.2.0")
+  s.add_runtime_dependency("prometheus-alert-buffer-client",  "~> 0.3.0")
   s.add_runtime_dependency("prometheus-api-client",           "~> 0.6")
 
   s.add_development_dependency("codeclimate-test-reporter", "~> 1.0.0")


### PR DESCRIPTION
This allows us to use newer versions of faraday (https://github.com/openshift/prometheus-alert-buffer-client-ruby/commit/2cfffa028df814e8f8ca8175aa7b07ce4817961a)