### PR TITLE
Make the credentials required in the provider DDF

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -51,6 +51,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
                       :id                     => 'authentications.default.valid',
                       :name                   => 'authentications.default.valid',
                       :skipSubmit             => true,
+                      :isRequired             => true,
                       :validationDependencies => %w[type],
                       :fields                 => [
                         {
@@ -154,6 +155,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
                       :id                     => "authentications.hawkular.valid",
                       :name                   => "authentications.hawkular.valid",
                       :skipSubmit             => true,
+                      :isRequired             => true,
                       :validationDependencies => ['type', "metrics_selection", "authentications.bearer.auth_key"],
                       :condition              => {
                         :when => "metrics_selection",
@@ -247,6 +249,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
                       :id                     => "authentications.prometheus.valid",
                       :name                   => "authentications.prometheus.valid",
                       :skipSubmit             => true,
+                      :isRequired             => true,
                       :validationDependencies => ['type', "metrics_selection", "authentications.bearer.auth_key"],
                       :condition              => {
                         :when => "metrics_selection",
@@ -367,6 +370,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
                       :id                     => "authentications.prometheus_alerts.valid",
                       :name                   => "authentications.prometheus_alerts.valid",
                       :skipSubmit             => true,
+                      :isRequired             => true,
                       :validationDependencies => ['type', "alerts_selection", "authentications.bearer.auth_key"],
                       :condition              => {
                         :when => "alerts_selection",
@@ -487,6 +491,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
                       :id                     => 'endpoints.virtualization.valid',
                       :name                   => 'endpoints.virtualization.valid',
                       :skipSubmit             => true,
+                      :isRequired             => true,
                       :validationDependencies => %w[type virtualization_selection],
                       :condition              => {
                         :when => 'virtualization_selection',


### PR DESCRIPTION
The default behavior for the `async-credentials` component is [changing to be optional](https://github.com/ManageIQ/manageiq-ui-classic/pull/7347), so it has to be explicitly marked as required here. This is a little different from any other provider, not just the default credentials are required as all the other components are only rendered when the user selects the right protocol from the dropdown.