### PR TITLE
Mark unused variable, remove redundant safe navigation

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -803,7 +803,7 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
     end
 
     def verify_hawkular_credentials(hostname, port, options)
-      !!hawkular_connect(hostname, port, options)&.avail&.get_data('all', :limit => 1)&.kind_of?(Array)
+      !!hawkular_connect(hostname, port, options)&.avail&.get_data('all', :limit => 1).kind_of?(Array)
     end
 
     def prometheus_connect(hostname, port, options)
@@ -823,7 +823,7 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
     end
 
     def verify_prometheus_credentials(hostname, port, options)
-      !!prometheus_connect(hostname, port, options)&.query(:query => "ALL")&.kind_of?(Hash)
+      !!prometheus_connect(hostname, port, options)&.query(:query => "ALL").kind_of?(Hash)
     end
 
     def verify_prometheus_alerts_credentials(hostname, port, options)

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -840,7 +840,7 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     end
   end
 
-  def parse_container_status(container, pod_id)
+  def parse_container_status(container, _pod_id)
     container_image = parse_container_image(container.image, container.imageID)
     return if container_image.nil?
 

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -471,7 +471,7 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
 
     unless pod.status.nil? || pod.status.containerStatuses.nil?
       pod.status.containerStatuses.each do |cn|
-        container_status = parse_container_status(cn, pod.metadata.uid)
+        container_status = parse_container_status(cn)
         if container_status.nil?
           _log.error("Invalid container status: pod - [#{pod.metadata.uid}] container - [#{cn}] [#{containers_index[cn.name]}]")
           next
@@ -840,7 +840,7 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     end
   end
 
-  def parse_container_status(container, _pod_id)
+  def parse_container_status(container)
     container_image = parse_container_image(container.image, container.imageID)
     return if container_image.nil?
 

--- a/spec/models/manageiq/providers/kubernetes/inventory/parser/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/inventory/parser/container_manager_spec.rb
@@ -457,16 +457,15 @@ describe ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager do
   describe "parse_container_status" do
     let(:image)   { "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ" }
     let(:imageID) { "docker://#{image}" }
-    let(:pod_id)  { "af3d1a10-23d3-11e5-44c0-0af3d1a10370e" }
 
     it "handles invalid image" do
       container = array_recursive_ostruct(:image => nil, :imageID => imageID)
-      expect(parser.send(:parse_container_status, container, pod_id)).to be_nil
+      expect(parser.send(:parse_container_status, container)).to be_nil
     end
 
     it "handles invalid imageID" do
       container = array_recursive_ostruct(:image => image, :imageID => nil)
-      expect(parser.send(:parse_container_status, container, pod_id)).to be_nil
+      expect(parser.send(:parse_container_status, container)).to be_nil
     end
   end
 


### PR DESCRIPTION
The rubocop linter picked up a couple things. Specifically, there's no need to do safe navigation on a `kind_of?` check since `NilClass` implements it.

I also marked the `pod_id` variable in `parse_container_status` as unused. I can remove it, but wasn't sure if the second argument was there to comply with an interface.