### PR TITLE
Remove unused port variable

### DIFF
--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -971,7 +971,6 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
 
     if image_ref.start_with?(ContainerImage::DOCKER_PULLABLE_PREFIX)
       hostname = image_ref_parts[:host] || image_ref_parts[:host2]
-      port = image_ref_parts[:port]
       digest = image_ref_parts[:digest]
     else
       hostname = image_parts[:host] || image_parts[:host2] || image_parts[:localhost]


### PR DESCRIPTION
Last of the linter warnings for now, this just removes a variable that was never used.