### PR TITLE
Fix instance connect options for username/password

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -999,8 +999,8 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
     options.merge(
       :hostname    => options[:hostname] || address,
       :port        => options[:port] || port,
-      :user        => options[:user] || authentication_userid(options[:auth_type]),
-      :pass        => options[:pass] || authentication_password(options[:auth_type]),
+      :username    => options[:username] || authentication_userid(options[:auth_type]),
+      :password    => options[:password] || authentication_password(options[:auth_type]),
       :bearer      => options[:bearer] || authentication_token(options[:auth_type] || 'bearer'),
       :http_proxy  => self.options ? self.options.fetch_path(:proxy_settings, :http_proxy) : nil,
       :ssl_options => options[:ssl_options] || {


### PR DESCRIPTION
The connect options for the class-level take `options[:username]` and `options[:password]` but the instance connect passes `options[:user]` and `options[:pass]`

These [`connect_options`](https://github.com/ManageIQ/manageiq-providers-kubernetes/blob/fc33713d32bcaa3a0b345aaa5f19dab1865c929a/app/models/manageiq/providers/kubernetes/container_manager.rb#L998-L1011) are passed directly to [`.raw_connect`](https://github.com/ManageIQ/manageiq-providers-kubernetes/blob/fc33713d32bcaa3a0b345aaa5f19dab1865c929a/app/models/manageiq/providers/kubernetes/container_manager.rb#L995) which is just [`kubernetes_connect`](https://github.com/ManageIQ/manageiq-providers-kubernetes/blob/fc33713d32bcaa3a0b345aaa5f19dab1865c929a/app/models/manageiq/providers/kubernetes/container_manager.rb#L58-L60) and none of the [openshift methods](https://github.com/ManageIQ/manageiq-providers-openshift/blob/master/app/models/manageiq/providers/openshift/container_manager.rb#L48-L67) deal with user/password.  Kubernetes connect call [`kubernetes_auth_options`](https://github.com/ManageIQ/manageiq-providers-kubernetes/blob/fc33713d32bcaa3a0b345aaa5f19dab1865c929a/app/models/manageiq/providers/kubernetes/container_manager.rb#L811)  which checks for and sets `:username` and `:password` not `:user` or `:password` [[ref]](https://github.com/ManageIQ/manageiq-providers-kubernetes/blob/fc33713d32bcaa3a0b345aaa5f19dab1865c929a/app/models/manageiq/providers/kubernetes/container_manager.rb#L828-L831)

Required for: https://github.com/ManageIQ/manageiq-providers-amazon/pull/679