### PR TITLE
Move Inventory WatchNotice under ContainerManager

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/runner.rb
@@ -83,9 +83,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner <
 
   def partial_refresh(notices)
     refresh_block do
-      collector = inventory_klass::Collector::WatchNotice.new(ems, notices)
-      persister = inventory_klass::Persister::WatchNotice.new(ems, nil)
-      parser    = inventory_klass::Parser::WatchNotice.new
+      collector = inventory_klass::Collector::ContainerManager::WatchNotice.new(ems, notices)
+      persister = inventory_klass::Persister::ContainerManager::WatchNotice.new(ems, nil)
+      parser    = inventory_klass::Parser::ContainerManager::WatchNotice.new
 
       parser.collector = collector
       parser.persister = persister

--- a/app/models/manageiq/providers/kubernetes/inventory/collector.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector.rb
@@ -1,6 +1,5 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   require_nested :ContainerManager
-  require_nested :WatchNotice
 
   def connect(service)
     manager.connect(:service => service)

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector
+  require_nested :WatchNotice
+
   def additional_attributes
     @additional_attributes ||= {} # TODO: is this used?
   end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager/watch_notice.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Collector
+class ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Collector
   attr_reader :additional_attributes, :pods, :replication_controllers,
               :namespaces, :nodes, :notices, :resource_quotas, :limit_ranges,
               :persistent_volumes, :persistent_volume_claims

--- a/app/models/manageiq/providers/kubernetes/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser.rb
@@ -1,6 +1,5 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   require_nested :ContainerManager
-  require_nested :WatchNotice
 
   def refresher_options
     Settings.ems_refresh[persister.manager.class.ems_type]

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -2,6 +2,8 @@ require 'bigdecimal'
 require 'shellwords'
 
 class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Parser
+  require_nested :WatchNotice
+
   include Vmdb::Logging
   include ManageIQ::Providers::Kubernetes::ContainerManager::EntitiesMapping
 

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager/watch_notice.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
+class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
   def parse
     parse_notices
 

--- a/app/models/manageiq/providers/kubernetes/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister.rb
@@ -1,4 +1,3 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister
+  require_nested :WatchNotice
+
   include ManageIQ::Providers::Kubernetes::Inventory::Persister::Definitions::ContainerCollections
 
   attr_reader :tag_mapper

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager/watch_notice.rb
@@ -1,0 +1,9 @@
+class ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
+  def targeted?
+    true
+  end
+
+  def strategy
+    :local_db_find_missing_references
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/watch_notice.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/watch_notice.rb
@@ -1,9 +1,0 @@
-class ManageIQ::Providers::Kubernetes::Inventory::Persister::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
-  def targeted?
-    true
-  end
-
-  def strategy
-    :local_db_find_missing_references
-  end
-end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -895,9 +895,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       allow(kube).to receive(:get_service).and_return(service)
       allow(ems).to receive(:connect).and_return(kube)
 
-      collector = ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice.new(ems, notices)
-      persister = ManageIQ::Providers::Kubernetes::Inventory::Persister::WatchNotice.new(ems, nil)
-      parser    = ManageIQ::Providers::Kubernetes::Inventory::Parser::WatchNotice.new
+      collector = ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager::WatchNotice.new(ems, notices)
+      persister = ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager::WatchNotice.new(ems, nil)
+      parser    = ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager::WatchNotice.new
 
       parser.collector = collector
       parser.persister = persister

--- a/spec/models/manageiq/providers/kubernetes/inventory/collector/container_manager/watch_notice_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/inventory/collector/container_manager/watch_notice_spec.rb
@@ -1,8 +1,8 @@
 autoload(:Kubeclient, 'kubeclient')
 
-describe ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice do
+describe ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager::WatchNotice do
   let(:ems)       { FactoryBot.create(:ems_kubernetes) }
-  let(:collector) { ManageIQ::Providers::Kubernetes::Inventory::Collector::WatchNotice.new(ems, notices) }
+  let(:collector) { described_class.new(ems, notices) }
   let(:service1)  { Kubeclient::Resource.new(:kind => "Service", :metadata => {:name => "app1", :namespace => "default"}) }
   let(:service2)  { Kubeclient::Resource.new(:kind => "Service", :metadata => {:name => "app2", :namespace => "default"}) }
   let(:endpoint1) { Kubeclient::Resource.new(:kind => "Endpoint", :metadata => {:name => "app1", :namespace => "default"}) }


### PR DESCRIPTION
If we include a `ContainerManager` in a vendor with e.g. a `CloudManager` then the `WatchNotice` is confusingly not visually a part of the `ContainerManager`.

E.g.:
```
amazon/inventory/collector/cloud_manager
amazon/inventory/collector/container_manager
amazon/inventory/collector/watch_notice # Not obvious that this is a container_manager collector
```

Co-depends:
https://github.com/ManageIQ/manageiq-providers-openshift/pull/204