### PR TITLE
Require hawkular metrics clients in container manager

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -851,7 +851,7 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
   end
 
   def self.hawkular_connect(hostname, port, options)
-    require "hawkular/hawkular_client"
+    require "hawkular/metrics/metrics_client"
 
     uri = raw_api_endpoint(hostname, port, options[:path] || "/hawkular/metrics")
     credentials = {:token => options[:bearer]}


### PR DESCRIPTION
from https://github.com/hawkular/hawkular-client-ruby:

```
You can also access each subproject's API individually, if you would like to use only the metrics API you could do

require 'hawkular/metrics/metrics_client'
metrics_client = Hawkular::Metrics::Client.new(
  entrypoint: 'http://localhost:8080/hawkular/metrics',
  credentials: { username: 'jdoe', password: 'password' },
  options: { tenant: 'hawkular' }
)
```


@miq-bot assign @agrare 

