### PR TITLE
Only collect metrics if the metrics endpoint has valid authentication

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -73,6 +73,10 @@ module ManageIQ::Providers
       end
     end
 
+    def metrics_connection(ems)
+      ems.connection_configurations.prometheus || ems.connection_configurations.hawkular
+    end
+
     def capture_context(ems, target, start_time, end_time)
       # make start_time align to minutes
       start_time = start_time.beginning_of_minute
@@ -97,6 +101,11 @@ module ManageIQ::Providers
 
       begin
         raise TargetValidationError, "no provider for #{target_name}" if ems.nil?
+
+        connection = metrics_connection(ems)
+        raise TargetValidationWarning, "no metrics endpoint found for #{target_name}" if connection.nil?
+        raise TargetValidationWarning, "metrics authentication isn't valid for #{target_name}" unless connection.authentication&.status == "Valid"
+
         context = capture_context(ems, target, start_time, end_time)
 
         raise TargetValidationWarning, "no metrics endpoint found for #{target_name}" if context.nil?

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -20,13 +20,13 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
       :ems_kubernetes,
       :connection_configurations => [{:endpoint       => {:role => :hawkular},
                                       :authentication => {:role => :hawkular}}],
-    )
+    ).tap { |ems| ems.authentications.each { |auth| auth.update!(:status => "Valid") } }
 
     @ems_kubernetes_prometheus = FactoryBot.create(
       :ems_kubernetes,
       :connection_configurations => [{:endpoint       => {:role => :prometheus},
                                       :authentication => {:role => :prometheus}}],
-    )
+    ).tap { |ems| ems.authentications.each { |auth| auth.update!(:status => "Valid") } }
 
     @node = FactoryBot.create(
       :kubernetes_node,


### PR DESCRIPTION
If the authentication for the metrics credentials is invalid we can end up spewing lots of huge log messages with the exception that is returned for each metrics target (can be thousands a minute).

```
[----] I, [2021-03-26T14:24:42.161946 #743495:145a0]  INFO -- : MIQ(ManageIQ::Providers::Openshift::ContainerManager::ContainerNode#just_perf_capture) [realtime] Capture for ManageIQ::Providers::Openshift::ContainerManager::ContainerNode name: [openshift.example.com], id: [1], start_time: [2021-03-26 00:00:00 UTC]...
[----] I, [2021-03-26T14:24:45.833725 #743495:145a0]  INFO -- : MIQ(ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture#perf_collect_metrics) Collecting metrics for ContainerNode(1) [realtime] [2021-03-26 00:00:00 UTC] []
[----] W, [2021-03-26T14:24:45.973769 #743495:145a0]  WARN -- : MIQ(ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture#perf_collect_metrics) [ContainerNode(1)] metrics authentication isn't valid for ContainerNode(1)
```