### PR TITLE
Handle a null byte in Node systemUUID

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/inventory/parser/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/inventory/parser/container_manager_spec.rb
@@ -724,6 +724,10 @@ describe ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager do
                                  :ext_management_system => @ems,
                                  :name                  => "instance_id")
       end
+
+      it "fails when there is a NULL byte in the providerID" do
+        @node[:identity_system] = "UUID\u0000"
+      end
     end
 
     context "succesful attempts" do


### PR DESCRIPTION
If the Node systemUUID contains a null byte the PostgreSQL query throws an exception