### PR TITLE
Strip any null bytes from systemUUID in node hash

### DIFF
--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -293,7 +293,7 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
   def cross_link_node(new_result)
     # Establish a relationship between this node and the vm it is on (if it is in the system)
     provider_id = new_result[:identity_infra]
-    bios_uuid   = new_result[:identity_system]&.gsub("\u0000", "")&.downcase
+    bios_uuid   = new_result[:identity_system]&.downcase
 
     host_instance   = find_host_by_provider_id(provider_id) if provider_id.present?
     host_instance ||= find_host_by_bios_uuid(bios_uuid) if bios_uuid.present?
@@ -330,7 +330,7 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
     if node_info
       new_result.merge!(
         :identity_machine           => node_info.machineID,
-        :identity_system            => node_info.systemUUID,
+        :identity_system            => node_info.systemUUID&.gsub("\u0000", ""),
         :container_runtime_version  => node_info.containerRuntimeVersion,
         :kubernetes_proxy_version   => node_info.kubeProxyVersion,
         :kubernetes_kubelet_version => node_info.kubeletVersion


### PR DESCRIPTION
When K8s is installed on power it has been seen that the nodes' systemUUID property contains null bytes.  This was causing the cross_link_node query to fail but once we get past that the save_inventory also fails.

Strip null bytes before saving the node hash to fix:
```
[----] I, [2021-05-20T15:17:49.836289 #456047:2ab88a5f7964]  INFO -- : EMS: [OCPpower], id: [16] Saving EMS Inventory...
[----] E, [2021-05-20T15:17:49.893094 #456047:2ab88a5f7964] ERROR -- : Error when saving InventoryCollection:<ContainerNode> with strategy: , saver_strategy: batch, targeted: false. Message: string contains null byte
[----] E, [2021-05-20T15:17:49.893391 #456047:2ab88a5f7964] ERROR -- : MIQ(ManageIQ::Providers::Openshift::ContainerManager::RefreshWorker::Runner#refresh_block) EMS [OCPpower], id: [16] Refresh failed: string contains null byte
[----] E, [2021-05-20T15:17:49.893593 #456047:2ab88a5f7964] ERROR -- : [ArgumentError]: string contains null byte  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2021-05-20T15:17:49.893791 #456047:2ab88a5f7964] ERROR -- : /opt/IBM/infrastructure-management-gemset/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/postgresql/quoting.rb:21:in `escape_string'
```