### PR TITLE
Restart the refresh worker when credentials change

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -18,11 +18,15 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
 
   include ManageIQ::Providers::Kubernetes::ContainerManager::Options
 
+  before_save :stop_event_monitor_queue_on_change, :stop_refresh_worker_queue_on_change
+  before_destroy :stop_event_monitor, :stop_refresh_worker
+
   supports :streaming_refresh do
     unsupported_reason_add(:streaming_refresh, _("Streaming refresh not enabled")) unless streaming_refresh_enabled?
   end
 
   supports :label_mapping
+
   def streaming_refresh_enabled?
     Settings.ems_refresh[emstype.to_sym]&.streaming_refresh
   end
@@ -62,6 +66,10 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
 
   def self.event_monitor_class
     ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher
+  end
+
+  def self.refresh_worker_class
+    self::RefreshWorker
   end
 
   def self.display_name(number = 1)
@@ -1053,6 +1061,11 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
     raise MiqException::MiqUnreachableError, err.message, err.backtrace
   rescue RestClient::Unauthorized   => err
     raise MiqException::MiqInvalidCredentialsError, err.message, err.backtrace
+  end
+
+  def after_update_authentication
+    super
+    stop_refresh_worker_queue_on_credential_change
   end
 
   def ensure_authentications_record

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -300,7 +300,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       expect(ems.monitoring_manager.parent_manager).to eq(ems)
 
       ems.endpoints = [FactoryBot.build(:endpoint, :role => 'default', :hostname => 'host3')]
-      queue_item = MiqQueue.find_by(:method_name => 'destroy')
+      queue_item = MiqQueue.find_by(:method_name => 'orchestrate_destroy')
       expect(queue_item).not_to be_nil
       expect(queue_item.instance_id).to eq(ems.monitoring_manager.id)
     end
@@ -371,7 +371,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       expect(ems.infra_manager.parent_manager).to eq(ems)
 
       ems.endpoints = [FactoryBot.build(:endpoint, :role => 'default', :hostname => 'host')]
-      queue_item = MiqQueue.find_by(:method_name => 'destroy')
+      queue_item = MiqQueue.find_by(:method_name => 'orchestrate_destroy')
       expect(queue_item).not_to be_nil
       expect(queue_item.instance_id).to eq(ems.infra_manager.id)
     end


### PR DESCRIPTION
If the credentials or hostname change we should restart the refresh worker to break the blocking open connections that use the old credentials/endpoint

- [x] Depends https://github.com/ManageIQ/manageiq/pull/21296

Fixes https://github.com/ManageIQ/manageiq/issues/21253