### PR TITLE
Allow duplicate hostnames with different ports

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -98,6 +98,21 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
     ems_type
   end
 
+  def hostname_uniqueness_valid?
+    return unless hostname_required?
+    return unless hostname.present? # Presence is checked elsewhere
+    # check uniqueness per provider type
+
+    existing_providers = self.class.all - [self]
+    existing_endpoints = existing_providers.map do |ems|
+      next if ems.hostname.nil?
+
+      "#{ems.hostname.downcase}:#{ems.port}"
+    end
+
+    errors.add(:hostname, N_("has to be unique per provider type")) if existing_endpoints.include?("#{hostname.downcase}:#{port}")
+  end
+
   def self.params_for_create
     {
       :fields => [

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -51,6 +51,18 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
     end
   end
 
+  describe "hostname_uniqueness_valid?" do
+    it "allows duplicate hostname with different ports" do
+      FactoryBot.create(:ems_kubernetes, :hostname => "k8s.local", :port => 6443)
+      expect { FactoryBot.create(:ems_kubernetes, :hostname => "k8s.local", :port => 443) }.not_to raise_error
+    end
+
+    it "rejects a second provider with duplicate hostname and port" do
+      FactoryBot.create(:ems_kubernetes, :hostname => "k8s.local", :port => 6443)
+      expect { FactoryBot.create(:ems_kubernetes, :hostname => "k8s.local", :port => 6443) }.to raise_error(ActiveRecord::RecordInvalid, /Hostname has to be unique per provider type/)
+    end
+  end
+
   context "#supports_metrics?" do
     before(:each) do
       EvmSpecHelper.local_miq_server(:zone => Zone.seed)


### PR DESCRIPTION
Override the base `hostname_uniqueness_valid?` method for container managers to allow for multiple EMSs with the same hostname but different ports.