### PR TITLE
Rename supports_metrics? method to metrics_endpoint_exists?

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -38,10 +38,10 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
   end
 
   supports :metrics do
-    unsupported_reason_add(:metrics, _("No metrics endpoint has been added")) unless supports_metrics?
+    unsupported_reason_add(:metrics, _("No metrics endpoint has been added")) unless metrics_endpoint_exists?
   end
 
-  def supports_metrics?
+  def metrics_endpoint_exists?
     endpoints.where(:role => METRICS_ROLES).exists?
   end
 


### PR DESCRIPTION
When calling `supports :metrics`, the SupportsFeatureMixin defines a `supports_metrics?` method via its
`define_supports_feature_methods` method [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/mixins/supports_feature_mixin.rb#L145)