### PR TITLE
Restart watch at previous resourceVersion on 401 Unauthenticated

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread_spec.rb
@@ -35,7 +35,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Watch
 
     it "updates the last resource_version" do
       expect(watch_thread).to receive(:resource_version=).with("2")
-      expect(watch_thread).to receive(:resource_version=).with(nil) # This is set when the watch loop breaks
 
       watch_thread.send(:collector_thread)
     end


### PR DESCRIPTION
If a watch exits with a 401 Unauthorized error we can still re-use the resourceVersion from the last notice.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/444

Closes https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/446