### PR TITLE
[MORPHY] Fix destroy queue item expectation

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -312,7 +312,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       expect(ems.monitoring_manager.parent_manager).to eq(ems)
 
       ems.endpoints = [FactoryBot.build(:endpoint, :role => 'default', :hostname => 'host3')]
-      queue_item = MiqQueue.find_by(:method_name => 'destroy')
+      queue_item = MiqQueue.find_by(:method_name => 'orchestrate_destroy')
       expect(queue_item).not_to be_nil
       expect(queue_item.instance_id).to eq(ems.monitoring_manager.id)
     end
@@ -383,7 +383,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       expect(ems.infra_manager.parent_manager).to eq(ems)
 
       ems.endpoints = [FactoryBot.build(:endpoint, :role => 'default', :hostname => 'host')]
-      queue_item = MiqQueue.find_by(:method_name => 'destroy')
+      queue_item = MiqQueue.find_by(:method_name => 'orchestrate_destroy')
       expect(queue_item).not_to be_nil
       expect(queue_item.instance_id).to eq(ems.infra_manager.id)
     end


### PR DESCRIPTION
(cherry picked from commit 2588e87b6fe291e1c50a72b3ff5ae25b28c62365)

Cherry-pick of https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/437/commits/2588e87b6fe291e1c50a72b3ff5ae25b28c62365 from https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/437

Fixes https://app.travis-ci.com/github/ManageIQ/manageiq-providers-kubernetes/builds/245733067