### PR TITLE
transition to supports(:metrics)

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_collector_worker.rb
@@ -11,7 +11,7 @@ module ManageIQ::Providers
     # Override PerEmsTypeWorkerMixin.emses_in_zone to limit metrics collection
     def self.emses_in_zone
       super.select do |ems|
-        ems.supports_metrics?.tap do |supported|
+        ems.supports?(:metrics).tap do |supported|
           _log.info("Skipping [#{ems.name}] since it has no metrics endpoint") unless supported
         end
       end

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -76,7 +76,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
         ]
       )
 
-      expect(ems.supports_metrics?).to be_falsey
+      expect(ems.supports?(:metrics)).to be_falsey
     end
 
     it "provider with prometheus endpoint has metrics support" do


### PR DESCRIPTION
We're migrating away from `supports_metrics?` to `supports?(:metrics)`