### PR TITLE
Update dependencies for ruby 3 support

### DIFF
--- a/manageiq-providers-kubernetes.gemspec
+++ b/manageiq-providers-kubernetes.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "image-inspector-client",          "~> 2.0"
-  spec.add_dependency "kubeclient",                      "~> 4.6"
+  spec.add_dependency "kubeclient",                      "~> 4.7"
   spec.add_dependency "more_core_extensions",            ">= 3.6", "< 5"
   spec.add_dependency "prometheus-alert-buffer-client",  "~> 0.3.0"
   spec.add_dependency "prometheus-api-client",           "~> 0.6"
 
   spec.add_development_dependency "manageiq-style"
-  spec.add_development_dependency "recursive-open-struct", "~> 1.0.0"
+  spec.add_development_dependency "recursive-open-struct", "~> 1.1"
   spec.add_development_dependency "simplecov", ">= 0.21.2"
 end


### PR DESCRIPTION
* kubeclient 4.7.0 added ruby 3 support in https://github.com/ManageIQ/kubeclient/pull 438
* Loosen recursive-open-struct requirement to allow kubeclient 4.7.0+.