### PR TITLE
Add allow_targeted_refresh to prevent fulls

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -32,6 +32,10 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
     Settings.ems_refresh[emstype.to_sym]&.streaming_refresh
   end
 
+  def allow_targeted_refresh?
+    true
+  end
+
   def monitoring_manager_needed?
     connection_configurations.roles.include?(
       ManageIQ::Providers::Kubernetes::MonitoringManagerMixin::ENDPOINT_ROLE.to_s


### PR DESCRIPTION
The EmsRefreshMixin checks for allow_targeted_refresh before queueing a target and it isn't supported it will queue a full.

This will cause the streaming refresher to shutdown all watch threads and do a full refresh again.

Ref: https://github.com/ManageIQ/manageiq-providers-vmware/pull/833