### PR TITLE
Fix the MetricsCollectorWorker running with invalid creds

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_collector_worker.rb
@@ -8,8 +8,8 @@ module ManageIQ::Providers
       @friendly_name ||= "C&U Metrics Collector for Kubernetes"
     end
 
-    # Override PerEmsTypeWorkerMixin.emses_in_zone to limit metrics collection
-    def self.emses_in_zone
+    # Override PerEmsTypeWorkerMixin.all_valid_ems_in_zone to limit metrics collection
+    def self.all_ems_in_zone
       super.select do |ems|
         ems.supports?(:metrics).tap do |supported|
           _log.info("Skipping [#{ems.name}] since it has no metrics endpoint") unless supported


### PR DESCRIPTION
The method do check for all valid EMSs in the zone has changed.

This was introduced by https://github.com/ManageIQ/manageiq/pull/21060 I didn't realize there were direct callers of [`emses_in_zone`](https://github.com/ManageIQ/manageiq/pull/21060/files#diff-e1cf43c568a786d79f0b65433e154483cc7a3abbdfbf6471cc54e2916ca94ea1L15-L17) I thought it was only used by [`any_valid_ems_in_zone?`](https://github.com/ManageIQ/manageiq/pull/21060/files#diff-e1cf43c568a786d79f0b65433e154483cc7a3abbdfbf6471cc54e2916ca94ea1L19-L21) which was changed to use the more standard `all_ems_in_zone` method

Follow-ups:
* Fix Openshift MetricsCollectorWorker
* Fix IBM Cloud IKS MetricsCollectorWorker