### PR TITLE
Fix blank metrics auth record being created

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -844,7 +844,8 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
       when 'kubevirt' # Kubevirt has its own authentication, no need for replication
         authentications << {'authtype' => 'kubevirt'} unless kubevirt
       else # Replicate the bearer authentication for any other endpoints
-        authentications << {'authtype' => endpoint['role']}.reverse_merge(bearer || {:auth_key => authentication_token})
+        auth_key = bearer&.fetch('auth_key', authentication_token)
+        authentications << {'authtype' => endpoint['role']}.reverse_merge(:auth_key => auth_key)
       end
     end
 


### PR DESCRIPTION
When editing a provider the auth_key isn't sent back down unless the auth was changed.  This led to a case where adding a metrics endpoint while editing a provider would create an authentication record without an auth_key resulting in a "Missing Credentials" on the subsequent validation.

Fixes https://github.com/ManageIQ/manageiq-providers-openshift/issues/237