### PR TITLE
Add after_update_endpoints to restart RefreshWorker

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -18,7 +18,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
 
   include ManageIQ::Providers::Kubernetes::ContainerManager::Options
 
-  before_save :stop_event_monitor_queue_on_change, :stop_refresh_worker_queue_on_change
   before_destroy :stop_event_monitor, :stop_refresh_worker
 
   supports :create
@@ -976,9 +975,14 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
     end
   end
 
-  def after_update_authentication
+  def after_update_authentication(changes)
     super
-    stop_refresh_worker_queue_on_credential_change
+    stop_refresh_worker_queue_on_credential_change(changes)
+  end
+
+  def after_update_endpoints(changes)
+    super
+    stop_refresh_worker_queue_on_change(changes)
   end
 
   def ensure_authentications_record


### PR DESCRIPTION
Restart the RefreshWorker after changes are made to the default endpoint

Related:
* https://github.com/ManageIQ/manageiq/pull/22269