### PR TITLE
Drop lib/gem-name.rb in favor of lib/gem/name.rb

### DIFF
--- a/lib/manageiq-providers-kubernetes.rb
+++ b/lib/manageiq-providers-kubernetes.rb
@@ -1,2 +1,0 @@
-require "manageiq/providers/kubernetes/engine"
-require "manageiq/providers/kubernetes/version"

--- a/lib/manageiq/providers/kubernetes.rb
+++ b/lib/manageiq/providers/kubernetes.rb
@@ -1,1 +1,2 @@
 require "manageiq/providers/kubernetes/engine"
+require "manageiq/providers/kubernetes/version"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 # NOTE: This repo's spec/support/ is also used by manageiq-providers-openshift.
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
-require "manageiq-providers-kubernetes"
+require "manageiq/providers/kubernetes"
 
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']


### PR DESCRIPTION
Adopt convention already supported by bundler and required by zeitwerk so we don't need to tell zeitwerk to ignore this lib/gem-name.rb file.