### PR TITLE
Fix Node network metrics collection on s390x

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context.rb
@@ -67,7 +67,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
       # prometheus field is in bytes
       # miq field is on kb ( / 1000 )
       if @metrics.include?('net_usage_rate_average')
-        interfaces = "eth.*|ens.*|enp.*|eno.*"
+        interfaces = "eth.*|ens.*|enp.*|eno.*|enc.*"
         net_resid = "sum(rate(container_network_receive_bytes_total{#{labels},interface=~\"#{interfaces}\"}[#{AVG_OVER}])) + " \
                     "sum(rate(container_network_transmit_bytes_total{#{labels},interface=~\"#{interfaces}\"}[#{AVG_OVER}]))"
         fetch_counters_data(net_resid, 'net_usage_rate_average', 1000.0)

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_node_metrics.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_node_metrics.yml
@@ -82,7 +82,7 @@ http_interactions:
   recorded_at: Thu, 04 Jun 2020 20:10:12 GMT
 - request:
     method: get
-    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))&start=1591300740&step=60s
+    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%7Cenc.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%7Cenc.*%22%7D%5B2m%5D))&start=1591300740&step=60s
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_node_timespan.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_node_timespan.yml
@@ -82,7 +82,7 @@ http_interactions:
   recorded_at: Thu, 04 Jun 2020 20:11:43 GMT
 - request:
     method: get
-    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))&start=1591300740&step=60s
+    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%7Cenc.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bid=%22/%22,job=%22kubelet%22,node=%22crc-dv9sm-master-0%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%7Cenc.*%22%7D%5B2m%5D))&start=1591300740&step=60s
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_pod_metrics.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_pod_metrics.yml
@@ -82,7 +82,7 @@ http_interactions:
   recorded_at: Thu, 04 Jun 2020 20:10:13 GMT
 - request:
     method: get
-    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))&start=1591300740&step=60s
+    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%7Cenc.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%7Cenc.*%22%7D%5B2m%5D))&start=1591300740&step=60s
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_pod_timespan.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_capture_context_pod_timespan.yml
@@ -82,7 +82,7 @@ http_interactions:
   recorded_at: Thu, 04 Jun 2020 20:11:43 GMT
 - request:
     method: get
-    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%22%7D%5B2m%5D))&start=1591300740&step=60s
+    uri: https://prometheus-k8s-openshift-monitoring.apps-crc.testing/api/v1/query_range?end=1591301400&query=sum(rate(container_network_receive_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%7Cenc.*%22%7D%5B2m%5D))%20%2B%20sum(rate(container_network_transmit_bytes_total%7Bjob=%22kubelet%22,namespace=%22openshift-service-catalog-controller-manager-operator%22,pod=%22openshift-service-catalog-controller-manager-operator-7c9f4hsgz%22,interface=~%22eth.*%7Cens.*%7Cenp.*%7Ceno.*%7Cenc.*%22%7D%5B2m%5D))&start=1591300740&step=60s
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Container Nodes on the s390x architecture have interfaces called `enc.*` which was causing no net_usage_rate_average values to be returned.

NOTE originally I reported that `br0` worked, and while it does x86 nodes also have a `br0` and we specifically request the underlying interfaces rather than the bridge.  For a fix for backport I wanted to maintain this behavior while investigating if there is a more reliable way of getting the metrics we're looking for.