### PR TITLE
Don't exclude all metrics if one counter is missing

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_mixin.rb
@@ -35,7 +35,11 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
       # Filtering out entries that are not containing all the metrics.
       # This generally happens because metrics are collected at slightly
       # different times and could produce entries that are incomplete.
-      @ts_values.select { |_, v| @metrics.all? { |k| v.key?(k) } }
+      #
+      # However, if a requested metric is missing from all timestamps
+      #  don't exclude all other values.
+      collected_metrics = @ts_values.values.flat_map(&:keys).uniq
+      @ts_values.select { |_, v| collected_metrics.all? { |k| v.key?(k) } }
     end
 
     def validate_target


### PR DESCRIPTION
Only filter out timestamps which have partial metric values for counters which exist in other timestamps.  If no timestamp has a counter then we should consider it requested but not returned and continue on.

https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/485