### PR TITLE
Fix method missing `:parent` should be module_parent

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -822,7 +822,7 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
   end
 
   def self.verify_prometheus_alerts_credentials(hostname, port, options)
-    !!parent::MonitoringManager.verify_credentials(
+    !!module_parent::MonitoringManager.verify_credentials(
       :url         => raw_api_endpoint(hostname, port),
       :path        => options[:path] || "/topics/alerts",
       :credentials => {:token => options[:bearer]},


### PR DESCRIPTION
```
[----] I, [2023-05-10T12:24:21.333269 #198911:9650]  INFO -- evm: MIQ(MiqTask#update_status) Task: [76] [Active] [Ok] [Task starting]
[----] E, [2023-05-10T12:24:21.443082 #198911:9650] ERROR -- evm: MIQ(MiqQueue#deliver) Message id: [341241], Error: [undefined local variable or method `parent' for ManageIQ::Providers::Openshift::ContainerManager:Class
Did you mean?  print]
[----] E, [2023-05-10T12:24:21.443267 #198911:9650] ERROR -- evm: [NameError]: undefined local variable or method `parent' for ManageIQ::Providers::Openshift::ContainerManager:Class
Did you mean?  print  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2023-05-10T12:24:21.443396 #198911:9650] ERROR -- evm: /home/grare/adam/.gem/ruby/3.0.0/gems/activerecord-6.1.7.3/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-providers-kubernetes-278692a957da/app/models/manageiq/providers/kubernetes/container_manager.rb:825:in `verify_prometheus_alerts_credentials'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-providers-kubernetes-278692a957da/app/models/manageiq/providers/kubernetes/container_manager.rb:716:in `block in verify_credentials'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-providers-kubernetes-278692a957da/app/models/manageiq/providers/kubernetes/container_manager.rb:724:in `connection_rescue_block'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-providers-kubernetes-278692a957da/app/models/manageiq/providers/kubernetes/container_manager.rb:705:in `verify_credentials'
/home/grare/adam/src/manageiq/manageiq/app/models/mixins/verify_credentials_mixin.rb:28:in `verify_credentials?'
```