### PR TITLE
Fix undefined rest client exceptions

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -721,6 +721,7 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
   end
 
   def self.connection_rescue_block
+    require "rest-client"
     yield
   rescue SocketError,
          Errno::ECONNREFUSED,


### PR DESCRIPTION
Fix undefined RestClient exceptions when verifying prometheus-alerts credentials.

Because the prometheus-alerts gem does not use rest-client unless you verify "default" credentials rest-client is not going to be required.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/487