### PR TITLE
Ensure WatchStream is always finished

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
@@ -30,7 +30,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::WatchThr
     return unless alive?
 
     finish.make_true
-    watch&.finish
+    watch&.finish rescue nil
     thread&.join(join_limit)
   end
 
@@ -83,6 +83,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::WatchThr
 
         retry_connection = false
         retry
+      ensure
+        watch.finish rescue nil
       end
     end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread_spec.rb
@@ -24,6 +24,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Watch
         .with("watch_#{entity_type}", :resource_version => resource_version)
         .and_return(watch)
 
+      allow(watch).to receive(:finish)
       allow(watch).to receive(:each).and_yield(notice).once
     end
 


### PR DESCRIPTION
Don't restart a watch without finishing the previous one