### PR TITLE
Removed the `auth_key` from list of Validation Dependencies in Metrics and Alerts

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -242,7 +242,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
                     :name                   => "authentications.prometheus.valid",
                     :skipSubmit             => true,
                     :isRequired             => true,
-                    :validationDependencies => ['type', "metrics_selection", "authentications.bearer.auth_key"],
+                    :validationDependencies => ['type', "metrics_selection"],
                     :condition              => {
                       :when => "metrics_selection",
                       :is   => 'prometheus',
@@ -364,7 +364,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
                     :name                   => "authentications.prometheus_alerts.valid",
                     :skipSubmit             => true,
                     :isRequired             => true,
-                    :validationDependencies => ['type', "alerts_selection", "authentications.bearer.auth_key"],
+                    :validationDependencies => ['type', "alerts_selection"],
                     :condition              => {
                       :when => "alerts_selection",
                       :is   => 'prometheus_alerts',


### PR DESCRIPTION
Right now, when editing the default endpoint token of a provider like Openshift, the provider form forces the user to revalidate the Metrics and Alerts endpoints as well however, this isn't apparent to the user unless they switch to that tab and check which can lead to confusion when trying to save.

Before:
![image](https://github.com/ManageIQ/manageiq-providers-kubernetes/assets/64800041/e59575fe-c197-4a87-bace-27c71cfd1a23)
![image](https://github.com/ManageIQ/manageiq-providers-kubernetes/assets/64800041/254d2d61-193e-4c73-9c82-69b8598a5e56)
![image](https://github.com/ManageIQ/manageiq-providers-kubernetes/assets/64800041/df5598e5-0c62-4e14-86d0-1e85dcda7791)

After:
![image](https://github.com/ManageIQ/manageiq-providers-kubernetes/assets/64800041/59a1cdc6-191a-48b9-bb12-6924b8735ba6)

**Note:** This is a temporary fix. The goal is to later undo this change and introduce a way for the ui to alert the user that they have to revalidate the other endpoints before saving their edits.