### PR TITLE
Check metrics authentication validity before perf_capture_queue

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -73,8 +73,6 @@ module ManageIQ::Providers
     end
 
     def verify_metrics_connection!(ems)
-      t = target || ems
-      target_name = "#{t.class.name.demodulize}(#{t.id})"
       raise TargetValidationError, "no provider for #{target_name}" if ems.nil?
 
       raise TargetValidationWarning, "no metrics endpoint found for #{target_name}" if metrics_connection(ems).nil?
@@ -96,9 +94,7 @@ module ManageIQ::Providers
       start_time ||= 15.minutes.ago.beginning_of_minute.utc
       ems = target.ext_management_system
 
-      target_name = "#{target.class.name.demodulize}(#{target.id})"
-      _log.info("Collecting metrics for #{target_name} [#{interval_name}] " \
-                "[#{start_time}] [#{end_time}]")
+      _log.info("Collecting metrics for #{target_name} [#{interval_name}] [#{start_time}] [#{end_time}]")
 
       begin
         context = build_capture_context!(ems, target, start_time, end_time)
@@ -129,6 +125,15 @@ module ManageIQ::Providers
 
       [{target.ems_ref => VIM_STYLE_COUNTERS},
        {target.ems_ref => context.ts_values}]
+    end
+
+    private
+
+    def target_name
+      @target_name ||= begin
+        t = target || ems
+        target_name = "#{t.class.name.demodulize}(#{t.id})"
+      end
     end
   end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -132,7 +132,7 @@ module ManageIQ::Providers
     def target_name
       @target_name ||= begin
         t = target || ems
-        target_name = "#{t.class.name.demodulize}(#{t.id})"
+        "#{t.class.name.demodulize}(#{t.id})"
       end
     end
   end

--- a/spec/factories/container_group.rb
+++ b/spec/factories/container_group.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :kubernetes_container_group, :parent => :container_group,
+          :class => "ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup"
+end

--- a/spec/factories/container_group.rb
+++ b/spec/factories/container_group.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
-  factory :kubernetes_container_group, :parent => :container_group,
-          :class => "ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup"
+  factory :kubernetes_container_group,
+          :parent => :container_group,
+          :class  => "ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup"
 end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -5,4 +5,17 @@ FactoryBot.define do
       zone
     end
   end
+
+  trait :with_metrics_endpoint do
+    after(:create) do |ems|
+      ems.endpoints << FactoryBot.create(:endpoint, :role => "prometheus")
+      ems.authentications << FactoryBot.create(:authentication, :authtype => "prometheus", :status => "Valid")
+    end
+  end
+
+  trait :with_invalid_auth do
+    after(:create) do |ems|
+      ems.authentications.update_all(:status => "invalid")
+    end
+  end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -22,6 +22,16 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
 
       expect(context).to be_a(described_class::PrometheusCaptureContext)
     end
+
+    context "on an invalid target" do
+      let(:group) { FactoryBot.create(:kubernetes_container_group, :ext_management_system => ems) }
+
+      it "raises an exception" do
+        metric_capture = described_class.new(group)
+        expect { metric_capture.build_capture_context!(ems, group, 5.minutes.ago, 0.minutes.ago) }
+          .to raise_error(described_class::TargetValidationWarning, "no associated node")
+      end
+    end
   end
 
   context "#perf_capture_all_queue" do

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -1,59 +1,24 @@
 describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
-  before do
-    # @miq_server is required for worker_settings to work
-    @miq_server = EvmSpecHelper.local_miq_server(:is_master => true)
-    @ems_kubernetes = FactoryBot.create(
-      :ems_kubernetes,
-      :connection_configurations => [{:endpoint       => {:role => :prometheus},
-                                      :authentication => {:role => :prometheus}}],
-    ).tap { |ems| ems.authentications.each { |auth| auth.update!(:status => "Valid") } }
-    @container_project = FactoryBot.create(:container_project, :ext_management_system => @ems_kubernetes)
-
-    @node = FactoryBot.create(
-      :kubernetes_node,
-      :name                  => 'node',
-      :ext_management_system => @ems_kubernetes,
-      :ems_ref               => 'target'
-    )
-
-    @node.computer_system.hardware = FactoryBot.create(
-      :hardware,
-      :cpu_total_cores => 2,
-      :memory_mb       => 2048
-    )
-
-    @group = FactoryBot.create(
-      :container_group,
-      :ext_management_system => @ems_kubernetes,
-      :container_node        => @node,
-      :ems_ref               => 'group'
-    )
-
-    @container = FactoryBot.create(
-      :kubernetes_container,
-      :name                  => 'container',
-      :container_group       => @group,
-      :container_project     => @container_project,
-      :ext_management_system => @ems_kubernetes,
-      :ems_ref               => 'target'
-    )
+  let(:ems)               { FactoryBot.create(:ems_kubernetes_with_zone, :with_metrics_endpoint) }
+  let(:container_project) { FactoryBot.create(:container_project,          :ext_management_system => ems) }
+  let!(:group)            { FactoryBot.create(:kubernetes_container_group, :ext_management_system => ems, :container_node => node) }
+  let!(:container)        { FactoryBot.create(:kubernetes_container,       :ext_management_system => ems, :container_group => group, :container_project => container_project) }
+  let(:node) do
+    FactoryBot.create(:kubernetes_node, :name => 'node', :ext_management_system => ems, :ems_ref => 'target').tap do |node|
+      node.computer_system.hardware = FactoryBot.create(:hardware, :cpu_total_cores => 2, :memory_mb => 2_048)
+    end
   end
 
   context "#perf_capture_object" do
     it "returns the correct class" do
-      expect(@ems_kubernetes.perf_capture_object.class).to eq(described_class)
+      expect(ems.perf_capture_object.class).to eq(described_class)
     end
   end
 
   context "#build_capture_context!" do
     it "detect prometheus metrics provider" do
-      metric_capture = described_class.new(@node)
-      context = metric_capture.build_capture_context!(
-        @ems_kubernetes,
-        @node,
-        5.minutes.ago,
-        0.minutes.ago
-      )
+      metric_capture = described_class.new(node)
+      context        = metric_capture.build_capture_context!(ems, node, 5.minutes.ago, 0.minutes.ago)
 
       expect(context).to be_a(described_class::PrometheusCaptureContext)
     end
@@ -61,45 +26,40 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
 
   context "#perf_capture_all_queue" do
     it "returns the objects" do
-      expect(@ems_kubernetes.perf_capture_object.perf_capture_all_queue).to include("Container" => [@container], "ContainerNode" => [@node])
+      expect(ems.perf_capture_object.perf_capture_all_queue).to include("Container" => [container], "ContainerGroup" => [group], "ContainerNode" => [node])
     end
 
     context "with a missing metrics endpoint" do
-      before do
-        @ems_kubernetes.endpoints.find_by(:role => "prometheus").destroy
-      end
+      let(:ems) { FactoryBot.create(:ems_kubernetes) }
 
       it "returns no objects" do
-        expect(@ems_kubernetes.perf_capture_object.perf_capture_all_queue).to be_empty
+        expect(ems.perf_capture_object.perf_capture_all_queue).to be_empty
       end
     end
 
     context "with invalid authentication on the metrics endpoint" do
-      before do
-        @ems_kubernetes.authentications.find_by(:authtype => "prometheus").update!(:status => "Error")
-        @ems_kubernetes.reload
-      end
+      let(:ems) { FactoryBot.create(:ems_kubernetes_with_zone, :with_metrics_endpoint, :with_invalid_auth) }
 
       it "returns no objects" do
-        expect(@ems_kubernetes.perf_capture_object.perf_capture_all_queue).to be_empty
+        expect(ems.perf_capture_object.perf_capture_all_queue).to be_empty
       end
     end
   end
 
   context "#perf_collect_metrics" do
     it "fails when no ems is defined" do
-      @node.ext_management_system = nil
-      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(described_class::TargetValidationError)
+      node.ext_management_system = nil
+      expect { node.perf_collect_metrics('interval_name') }.to raise_error(described_class::TargetValidationError)
     end
 
     it "fails when no cpu cores are defined" do
-      @node.hardware.cpu_total_cores = nil
-      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(described_class::TargetValidationError)
+      node.hardware.cpu_total_cores = nil
+      expect { node.perf_collect_metrics('interval_name') }.to raise_error(described_class::TargetValidationError)
     end
 
     it "fails when memory is not defined" do
-      @node.hardware.memory_mb = nil
-      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(described_class::TargetValidationError)
+      node.hardware.memory_mb = nil
+      expect { node.perf_collect_metrics('interval_name') }.to raise_error(described_class::TargetValidationError)
     end
   end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -59,6 +59,33 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
     end
   end
 
+  context "#perf_capture_all_queue" do
+    it "returns the objects" do
+      expect(@ems_kubernetes.perf_capture_object.perf_capture_all_queue).to include("Container" => [@container], "ContainerNode" => [@node])
+    end
+
+    context "with a missing metrics endpoint" do
+      before do
+        @ems_kubernetes.endpoints.find_by(:role => "prometheus").destroy
+      end
+
+      it "returns no objects" do
+        expect(@ems_kubernetes.perf_capture_object.perf_capture_all_queue).to be_empty
+      end
+    end
+
+    context "with invalid authentication on the metrics endpoint" do
+      before do
+        @ems_kubernetes.authentications.find_by(:authtype => "prometheus").update!(:status => "Error")
+        @ems_kubernetes.reload
+      end
+
+      it "returns no objects" do
+        expect(@ems_kubernetes.perf_capture_object.perf_capture_all_queue).to be_empty
+      end
+    end
+  end
+
   context "#perf_collect_metrics" do
     it "fails when no ems is defined" do
       @node.ext_management_system = nil

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -45,10 +45,10 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
     end
   end
 
-  context "#capture_context" do
+  context "#build_capture_context!" do
     it "detect prometheus metrics provider" do
       metric_capture = described_class.new(@node)
-      context = metric_capture.capture_context(
+      context = metric_capture.build_capture_context!(
         @ems_kubernetes,
         @node,
         5.minutes.ago,


### PR DESCRIPTION
Check that the EMS's metrics authentication is valid before queueing perf_capture calls, potentially flooding the queue with calls that are going to fail later.