### PR TITLE
Improve performance capture ems targets

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -57,7 +57,12 @@ module ManageIQ::Providers
         return []
       end
 
-      super
+      MiqPreloader.preload([ems], :container_images => :tags, :container_nodes => :tags, :container_groups => [:tags, :containers => :tags])
+
+      with_archived(ems.all_container_nodes) +
+        with_archived(ems.all_container_groups) +
+        with_archived(ems.all_containers) +
+        with_archived(ems.container_images)
     end
 
     def prometheus_capture_context(target, start_time, end_time)


### PR DESCRIPTION
For Kubernetes type providers if the ems has metrics credentials then all instances of container_nodes, container_groups, etc... supports capture.
    
We don't have to check `.supporting(:capture)` if we are in a kubernetes provider, but this isn't generally true so only implement this behavior in k8s.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/493