### PR TITLE
Revert "Merge pull request #492 from DavidResende0/remove-validation-dependecies"

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -242,7 +242,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
                     :name                   => "authentications.prometheus.valid",
                     :skipSubmit             => true,
                     :isRequired             => true,
-                    :validationDependencies => ['type', "metrics_selection"],
+                    :validationDependencies => ['type', "metrics_selection", "authentications.bearer.auth_key"],
                     :condition              => {
                       :when => "metrics_selection",
                       :is   => 'prometheus',
@@ -364,7 +364,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
                     :name                   => "authentications.prometheus_alerts.valid",
                     :skipSubmit             => true,
                     :isRequired             => true,
-                    :validationDependencies => ['type', "alerts_selection"],
+                    :validationDependencies => ['type', "alerts_selection", "authentications.bearer.auth_key"],
                     :condition              => {
                       :when => "alerts_selection",
                       :is   => 'prometheus_alerts',


### PR DESCRIPTION
This reverts commit 7be0a737edac7c0af5b43fdef6bfac1627826a33, reversing changes made to 6acc47038cebd128bb542d0b4ce85c65f53315c8.

This commit caused a bigger issue in that metric validation fails entirely.