### PR TITLE
Fix started_at/finished_at always being nil

### DIFF
--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -851,13 +851,16 @@ class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < Man
 
   def parse_container_state(state_hash)
     return {} if state_hash.to_h.empty?
-    res = {}
+
     # state_hash key is the state and value are attributes e.g 'running': {...}
-    (state, state_info), = state_hash.to_h.to_a
-    res[:state] = state
-    %w(reason started_at finished_at exit_code signal message).each do |attr|
-      res[attr.to_sym] = state_info[attr.camelize(:lower)]
+    (state, state_info), = state_hash.to_h.deep_symbolize_keys.to_a
+
+    res = {:state => state}
+
+    %i[reason reason started_at startedAt finished_at finishedAt exit_code exitCode signal signal message message].each_slice(2) do |attr, state_info_attr|
+      res[attr] = state_info[state_info_attr]
     end
+
     res
   end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -108,14 +108,10 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
           # :backing_ref => "docker://87cd51044d7175c246fa1fa7699253fc2aecb769021837a966fa71e9dcb54d71"
         )
 
-        [
-          @container.started_at,
-          @container.finished_at,
-          @container.last_started_at,
-          @container.last_finished_at,
-        ].each do |date_|
-          expect(date_.kind_of?(ActiveSupport::TimeWithZone) || date_.kind_of?(NilClass)).to be_truthy
-        end
+        expect(@container.started_at).to be_kind_of(ActiveSupport::TimeWithZone)
+        expect(@container.finished_at).to be_nil
+        expect(@container.last_started_at).to be_kind_of(ActiveSupport::TimeWithZone)
+        expect(@container.last_finished_at).to be_kind_of(ActiveSupport::TimeWithZone)
 
         expect(@container.container_image.name).to eq("kubernetes/heapster")
         expect(@container.command).to eq("/heapster --source\\=kubernetes:https://kubernetes "\


### PR DESCRIPTION
The `state_info` had symbol keys like `:startedAt` and `:finishedAt` and we were looking for string keys like `"startedAt"` and `"finishedAt"` causing these values to always be `nil` even if data existed in the API response.