### PR TITLE
Convert the duration to a float

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker/watch_thread.rb
@@ -31,7 +31,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::WatchThr
 
     finish.make_true
     watch&.finish rescue nil
-    thread&.join(join_limit)
+    thread&.join(join_limit.to_f)
   end
 
   protected


### PR DESCRIPTION
Thread#join used to accept duration objects but not since ruby 3/rails 6.1

See also https://github.com/ManageIQ/manageiq-providers-vmware/pull/832