### PR TITLE
Added Helper Text To the Token Field

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -203,6 +203,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
                         :id         => "authentications.bearer.auth_key",
                         :name       => "authentications.bearer.auth_key",
                         :label      => "Token",
+                        :helperText => _('Note: If enabled, the Default, Metrics, and Alert Endpoints must be revalidated when adding or changing the token'),
                         :type       => "password",
                         :isRequired => true,
                         :validate   => [{:type => "required"}],


### PR DESCRIPTION
Adds some text to the Token Field notifying the user that the Default, Metrics, and Alerts endpoints must be revalidated anytime the Token is updated if that endpoint is enabled.

Before:
![image](https://github.com/ManageIQ/manageiq-providers-kubernetes/assets/64800041/55f383af-e80c-4992-a48e-c22ad075e6bb)

After:
![image](https://github.com/ManageIQ/manageiq-providers-kubernetes/assets/64800041/cccdc329-3d12-4c26-bd73-61c4dd0b556d)

The long term goal is to add a clearer visual cue that illustrates this fact to the user.