### PR TITLE
Fix No Method get_nodes for NilClass invalid token

### DIFF
--- a/app/models/manageiq/providers/kubernetes/inventory/collector.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector.rb
@@ -1,13 +1,11 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   require_nested :ContainerManager
 
-  def connect(service)
+  def connect!(service)
     manager.connect(:service => service)
-  rescue KubeException
-    nil
   end
 
   def kubernetes_connection
-    @kubernetes_connection ||= connect("kubernetes")
+    @kubernetes_connection ||= connect!("kubernetes")
   end
 end


### PR DESCRIPTION
If a token is invalid when a refresh starts the connect method was eating the exception and returning `nil` rather than allowing the refresh to fail.