### PR TITLE
Reject any events which do not have a timestamp

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -48,6 +48,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
 
   def queue_event(event)
     event_data = extract_event_data(event)
+    return if event_data.nil?
+
     _log.info "#{log_prefix} Queuing event [#{event_data}]"
     event_hash = ManageIQ::Providers::Kubernetes::ContainerManager::EventParser.event_to_hash(event_data, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
@@ -55,6 +57,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
 
   def filtered?(event)
     event_data = extract_event_data(event)
+    return true if event_data.nil?
 
     supported_reasons = ENABLED_EVENTS[event_data[:kind]] || []
     !supported_reasons.include?(event_data[:reason]) || filtered_events.include?(event_data[:event_type])
@@ -73,10 +76,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
       :event_uid => event.object.metadata.uid,
     }
 
+    # If there is no timestamp we cannot properly handle the event
+    return if event_data[:timestamp].nil?
+
     unless event.object.involvedObject.fieldPath.nil?
       event_data[:fieldpath] = event.object.involvedObject.fieldPath
     end
-
 
     event_type_prefix = event_data[:kind].upcase
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin_spec.rb
@@ -256,6 +256,12 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           ))
         end
 
+        let(:missing_timestamp_event) do
+          array_recursive_ostruct(:object => kubernetes_event.merge(
+            'lastTimestamp' => nil
+          ))
+        end
+
         it 'without matching node returns nil uid' do
           expect(test_class.new(ems).extract_event_data(bad_uid_event)[:uid]).to eq(nil)
           expect(test_class.new(ems).extract_event_data(missing_uid_event)[:uid]).to eq(nil)
@@ -269,6 +275,10 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
 
           expect(test_class.new(ems).extract_event_data(bad_uid_event)).to eq(expected_data)
           expect(test_class.new(ems).extract_event_data(missing_uid_event)).to eq(expected_data)
+        end
+
+        it 'with missing timestamp' do
+          expect(test_class.new(ems).extract_event_data(missing_timestamp_event)).to be_nil
         end
       end
     end
@@ -287,6 +297,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           'metadata'       => {
             'uid' => 'SomeRandomUid',
           },
+          'lastTimestamp'  => '2016-07-25T11:45:34Z',
         }
       end
 
@@ -306,6 +317,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin do
           'metadata'       => {
             'uid' => 'SomeRandomUid',
           },
+          'lastTimestamp'  => '2016-07-25T11:45:34Z',
         }
       end
 


### PR DESCRIPTION
The event timestamp is critical for uniquely identifying events and ensuring there are no duplicates.

We cannot properly handle events without a timestamp so we need to not queue these for the event handler.