### PR TITLE
[WIP] Add some debugging for kubeclient

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -643,11 +643,25 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
       }
     )
 
+    debug_kubeclient(conn)
+
     # Test the API endpoint at connect time to prevent exception being raised
     # on first method call
     conn.discover
 
     conn
+  end
+
+  def self.debug_kubeclient(conn)
+    return unless defined?($log) && $log.debug?
+
+    if conn.respond_to?(:configure_faraday)
+      conn.configure_faraday { |faraday| faraday.response :logger }
+    else
+      RestClient.log = STDOUT
+    end
+
+    Kubeclient::Common::WatchStream.prepend(ManageIQ::Providers::Kubernetes::DebugKubeclientWatch)
   end
 
   def self.kubernetes_auth_options(options)

--- a/lib/manageiq/providers/kubernetes/debug_kubeclient_watch.rb
+++ b/lib/manageiq/providers/kubernetes/debug_kubeclient_watch.rb
@@ -1,0 +1,13 @@
+require 'kubeclient'
+
+module ManageIQ
+  module Providers
+    module Kubernetes
+      module DebugKubeclientWatch
+        def build_client
+          super.use(logging: { logger: Logger.new($stderr) })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Kubeclient uses RestClient for 4.x versions for the main connection but the http gem for watches.  On master, kubeclient uses faraday for main connections.  This commit provides a way to patch restclient/faraday and http to add logging of request/response.

TODO: We will need to provide a way to sanitize passwords and possibly other information.