### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -1,18 +1,4 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::ContainerManager
-  require_nested :Container
-  require_nested :ContainerGroup
-  require_nested :ContainerNode
-  require_nested :ContainerTemplate
-  require_nested :EventCatcher
-  require_nested :EventCatcherMixin
-  require_nested :EventParser
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :Scanning
-  require_nested :Options
-
   DEFAULT_PORT = 6443
   METRICS_ROLES = %w[prometheus].freeze
 

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -15,8 +15,6 @@ module ManageIQ::Providers
       end
     end
 
-    require_nested :PrometheusCaptureContext
-
     INTERVAL = 60.seconds
 
     VIM_STYLE_COUNTERS = {

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_collector_worker.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers
   class Kubernetes::ContainerManager::MetricsCollectorWorker < BaseManager::MetricsCollectorWorker
-    require_nested :Runner
-
     self.default_queue_name = "kubernetes"
 
     def friendly_name

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_worker.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-  require_nested :WatchThread
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning
-  require_nested :Job
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -3,8 +3,6 @@ autoload(:Kubeclient, 'kubeclient')
 autoload(:KubeException, 'kubeclient')
 
 class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
-  require_nested :Dispatcher
-
   PROVIDER_CLASS = ManageIQ::Providers::Kubernetes::ContainerManager
   INSPECTOR_IMAGE_TAG = '2.1'.freeze
   INSPECTOR_PORT = 8080

--- a/app/models/manageiq/providers/kubernetes/inventory.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::Kubernetes::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :ContainerManager
-
   def connect!(service)
     manager.connect(:service => service)
   end

--- a/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/collector/container_manager.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector
-  require_nested :WatchNotice
-
   def additional_attributes
     @additional_attributes ||= {} # TODO: is this used?
   end

--- a/app/models/manageiq/providers/kubernetes/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :ContainerManager
-
   def refresher_options
     Settings.ems_refresh[persister.manager.class.ems_type]
   end

--- a/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/parser/container_manager.rb
@@ -2,8 +2,6 @@ require 'bigdecimal'
 require 'shellwords'
 
 class ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Parser
-  require_nested :WatchNotice
-
   include Vmdb::Logging
   include ManageIQ::Providers::Kubernetes::ContainerManager::EntitiesMapping
 

--- a/app/models/manageiq/providers/kubernetes/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :ContainerManager
 end

--- a/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/container_manager.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister
-  require_nested :WatchNotice
-
   include ManageIQ::Providers::Kubernetes::Inventory::Persister::Definitions::ContainerCollections
 
   attr_reader :tag_mapper

--- a/app/models/manageiq/providers/kubernetes/monitoring_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/monitoring_manager.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers
   class Kubernetes::MonitoringManager < ManageIQ::Providers::MonitoringManager
-    require_nested :EventCatcher
-
     ENDPOINT_ROLE = :prometheus_alerts
 
 

--- a/app/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/kubernetes/monitoring_manager/event_catcher.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-  require_nested :RunnerMixin
-  require_nested :Stream
-
   def self.settings_name
     :event_catcher_prometheus
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854