### PR TITLE
Require kubeclient in connection_rescue_block

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -586,6 +586,7 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
   end
 
   def self.connection_rescue_block
+    require "kubeclient"
     require "rest-client"
     yield
   rescue SocketError,


### PR DESCRIPTION
Ensure that the Kubeclient::HttpError exception class is loaded in the connection_rescue_block method when verifying the prometheus endpoint.

```
[NameError]: uninitialized constant ManageIQ::Providers::Kubernetes::ContainerManager::Kubeclient
  rescue RestClient::Unauthorized, Kubeclient::HttpError => err
ERROR -- evm: /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-providers-kubernetes-7e766229622c/app/models/manageiq/providers/kubernetes/container_manager.rb:596:in `rescue in connection_rescue_block'
  /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-providers-kubernetes-7e766229622c/app/models/manageiq/providers/kubernetes/container_manager.rb:588:in `connection_rescue_block'
  /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-providers-kubernetes-7e766229622c/app/models/manageiq/providers/kubernetes/container_manager.rb:570:in `verify_credentials'
  /var/www/miq/vmdb/app/models/mixins/verify_credentials_mixin.rb:28:in `verify_credentials?'                                   ^^^^^^^^^^
```