### PR TITLE
Fix prometheus http_proxy using 0.0.0.0:80

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -662,8 +662,9 @@ Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
     credentials = {:token => options[:bearer]}
     ssl_options = options[:ssl_options] || {:verify_ssl => OpenSSL::SSL::VERIFY_NONE}
 
+    http_proxy_uri = options[:http_proxy] || VMDB::Util.http_proxy_uri.to_s
     prometheus_options = {
-      :http_proxy_uri => options[:http_proxy] || VMDB::Util.http_proxy_uri.to_s,
+      :http_proxy_uri => http_proxy_uri.presence,
       :verify_ssl     => ssl_options[:verify_ssl],
       :ssl_cert_store => ssl_options[:ca_file],
     }

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_client_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_client_mixin.rb
@@ -36,7 +36,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Promet
     worker_class = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker
 
     {
-      :http_proxy_uri => VMDB::Util.http_proxy_uri.to_s,
+      :http_proxy_uri => VMDB::Util.http_proxy_uri.to_s.presence,
       :verify_ssl     => @ext_management_system.verify_ssl_mode(prometheus_endpoint),
       :ssl_cert_store => @ext_management_system.ssl_cert_store(prometheus_endpoint),
       :open_timeout   => worker_class.worker_settings[:prometheus_open_timeout] || 5,


### PR DESCRIPTION
When `VMDB::Util.http_proxy_uri` is `nil` `VMDB::Util.http_proxy_uri.to_s` is `""`.

With uri v0.10.3 `URI.parse("http://")` would have a `host` of `nil` but on v0.13.0 `URI.parse("http://")` has a `host` of `""`.

This was causing Faraday to use a proxy of `0.0.0.0:80` instead of none.

`prometheus-api-client-0.6.2/lib/prometheus/api_client/client.rb:106:in 'rescue in run_command': Failed to open TCP connection to :80 (Connection refused - connect(2) for 0.0.0.0:80) (Prometheus::ApiClient::Client::RequestError)`