### PR TITLE
Delay load prometheus client

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_client_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/prometheus_client_mixin.rb
@@ -1,6 +1,4 @@
 module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::PrometheusClientMixin
-  require 'prometheus/api_client'
-
   def prometheus_client
     @prometheus_uri ||= prometheus_uri
     @prometheus_credentials ||= prometheus_credentials
@@ -10,6 +8,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Promet
   end
 
   def prometheus_client_new(uri, credentials, options)
+    require 'prometheus/api_client'
+
     Prometheus::ApiClient.client(
       :url         => uri.to_s,
       :options     => options,


### PR DESCRIPTION
Most of the overhead is eager loading faraday but there's no need for domain models to load this client until it's needed by code needing this client.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
