### PR TITLE
Add annotations to container summary pages

### DIFF
--- a/app/models/manageiq/providers/kubernetes/inventory/persister/definitions/container_collections.rb
+++ b/app/models/manageiq/providers/kubernetes/inventory/persister/definitions/container_collections.rb
@@ -58,23 +58,23 @@ module ManageIQ::Providers::Kubernetes::Inventory::Persister::Definitions::Conta
   def initialize_custom_attributes
     %i(container_nodes
        container_projects).each do |name|
-      add_custom_attributes(name, %w(labels additional_attributes))
+      add_custom_attributes(name, %w(labels additional_attributes annotations))
     end
 
     %i(container_groups).each do |name|
-      add_custom_attributes(name, %w(labels node_selectors))
+      add_custom_attributes(name, %w(labels node_selectors annotations))
     end
 
     %i(container_replicators
        container_services).each do |name|
-      add_custom_attributes(name, %w(labels selectors))
+      add_custom_attributes(name, %w(labels selectors annotations))
     end
 
     %i(container_builds
        container_build_pods
        container_routes
        container_templates).each do |name|
-      add_custom_attributes(name, %w(labels))
+      add_custom_attributes(name, %w(labels annotations))
     end
   end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -149,6 +149,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
           :dns_policy     => "ClusterFirst",
           :phase          => "Running"
         )
+        expect(@containergroup.annotations).to contain_exactly(
+          annotation_with_name("kubernetes.io/created-by")
+        )
         expect(@containergroup.labels).to contain_exactly(
           label_with_name_value("name", "heapster")
         )
@@ -404,6 +407,14 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
         an_object_having_attributes(
           :section => 'labels', :source => 'kubernetes',
           :name => name, :value => value
+        )
+      end
+
+      def annotation_with_name(name)
+        have_attributes(
+          :section => 'annotations',
+          :source  => 'kubernetes',
+          :name    => name
         )
       end
 


### PR DESCRIPTION
Add parse_annotations method and add them to custom attributes of container summary pages that have labels

Relevant PRs:
UI-Classic: https://github.com/ManageIQ/manageiq-ui-classic/pull/9214
Providers-Openshift: https://github.com/ManageIQ/manageiq-providers-openshift/pull/262
Core ManageIQ: https://github.com/ManageIQ/manageiq/pull/23074


Cross-Repo Tests:
https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/879 
All passing except for known failing test cases in core ManageIQ
