### PR TITLE
Provide backward compatible way to globally set permitted classes

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job/dispatcher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job/dispatcher_spec.rb
@@ -40,7 +40,12 @@ RSpec.describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job:
     context "with container and vms jobs" do
       let(:container_image_classes) { ContainerImage.descendants.collect(&:name).append('ContainerImage') }
       before do
-        ActiveRecord::Base.yaml_column_permitted_classes |=  [ManageIQ::Providers::Openshift::ContainerManager::ContainerImage]
+        if ActiveRecord.respond_to?(:yaml_column_permitted_classes)
+          ActiveRecord.yaml_column_permitted_classes       = YamlPermittedClasses.app_yaml_permitted_classes | [ManageIQ::Providers::Openshift::ContainerManager::ContainerImage]
+        else
+          ActiveRecord::Base.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes | [ManageIQ::Providers::Openshift::ContainerManager::ContainerImage]
+        end
+
         @jobs = (@vms + @repo_vms).collect(&:raw_scan)
         User.current_user = FactoryBot.create(:user)
         @jobs += @container_images.map { |img| img.ext_management_system.raw_scan_job_create(img.class, img.id) }


### PR DESCRIPTION
This supports rails 7 and 6.1.

Similar to the change in: https://github.com/ManageIQ/manageiq/pull/22887

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
