### PR TITLE
Remove newlines from help message

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -520,9 +520,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
                     :id          => 'options.image_inspector_options.cve_url',
                     :name        => 'options.image_inspector_options.cve_url',
                     :label       => _('CVE Location'),
-                    :helperText  => _('Enables defining a URL path prefix for XCCDF file instead of accessing the default location.
-example: http://my_file_server.org:3333/xccdf_files/
-Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
+                    :helperText  => _('Alternative URL path for the XCCDF file, where a com.redhat.rhsa-RHEL7.ds.xml.bz2 file is expected. example: http://my_file_server.example.org:3333/xccdf_files/'),
                     :placeholder => ::Settings.ems.ems_kubernetes.image_inspector_cve_url
                   },
                 ],

--- a/app/models/manageiq/providers/kubernetes/container_manager/options.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/options.rb
@@ -47,9 +47,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::Options
             },
             :cve_url     => {
               :label          => N_('CVE Location'),
-              :help_text      => N_('Enables defining a URL path prefix for XCCDF file instead of accessing the default location.
-  example: http://my_file_server.org:3333/xccdf_files/
-  Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there.'),
+              :help_text      => N_('Alternative URL path for the XCCDF file, where a com.redhat.rhsa-RHEL7.ds.xml.bz2 file is expected. example: http://my_file_server.example.org:3333/xccdf_files/'),
+
               # Future versions of image inspector will extend this.
               :global_default => ::Settings.ems.ems_kubernetes.image_inspector_cve_url,
             },


### PR DESCRIPTION
Newlines can cause trouble with translations as well as presentation in the UI. This particular string doesn't actually need the newlines, so this commit changes it to just not have them.

Alternative to ManageIQ/manageiq#23213

@agrare Please review. cc @jrafanie 

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
