### PR TITLE
Fix Scanning Job spec failure private method

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -260,7 +260,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
     context "using provider options and settings" do
       def create_pod_definition
         allow_any_instance_of(described_class).to receive_messages(:kubernetes_client => MockKubeClient.new)
-        kc = @job.kubernetes_client
+
         secret_name = @job.send(:inspector_admin_secrets)
         @job.send(:pod_definition, secret_name)
       end
@@ -316,7 +316,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
 
     it 'should send correct dockercfg secrets' do
       allow(@job).to receive(:kubernetes_client).and_return(MockKubeClient.new)
-      kc = @job.kubernetes_client
+
       secret_names = @job.send(:inspector_admin_secrets)
       pod = @job.send(:pod_definition, secret_names)
       secret_name = secret_names.first

--- a/spec/support/array_recursive_ostruct.rb
+++ b/spec/support/array_recursive_ostruct.rb
@@ -1,5 +1,7 @@
 # Helps constructing inputs similar to kubeclient results
 module ArrayRecursiveOpenStruct
+  require 'recursive-open-struct'
+
   def array_recursive_ostruct(hash)
     RecursiveOpenStruct.new(hash, :recurse_over_arrays => true)
   end


### PR DESCRIPTION
Fix private method kubernetes_client failures in Container Scanning Job spec

```
Failures:

1) ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job A single Container Scan Job, should send correct dockercfg secrets
   Failure/Error: kc = @job.kubernetes_client

   NoMethodError:
     private method `kubernetes_client' called for #<ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job:0x00007f3ee9a38e80>
   # ./spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb:319:in `block (3 levels) in <top (required)>'
```

This appears to have been failing since https://github.com/ManageIQ/manageiq-providers-kubernetes/actions/runs/14785948601 likely due to a dependency gem change.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
