### PR TITLE
Kubernetes pod terminal added

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/container_group.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_group.rb
@@ -1,7 +1,47 @@
+require "pty"
+
 class ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup < ::ContainerGroup
   alias_attribute :pod_uid, :ems_ref
 
   supports :capture
+
+  def raw_start_terminal_session
+    opts = ext_management_system.connect_options
+
+    pty_out, pty_in, pid = PTY.spawn(
+      terminal_binary, "exec", "-it", name,
+      "-n", container_project.name,
+      "-c", containers.first.name,
+      "--server=https://#{opts[:hostname]}:#{opts[:port]}",
+      "--token=#{opts[:bearer]}",
+      "--insecure-skip-tls-verify",
+      "--", "/bin/sh"
+    )
+
+    { :pty_in => pty_in, :pty_out => pty_out, :pid => pid }
+  end
+
+  def raw_send_terminal_input(data)
+    session = POD_SESSIONS[id.to_s]
+    return unless session
+
+    session[:pty_in].write(data)
+    session[:pty_in].flush
+  end
+
+  def raw_stop_terminal_session
+    session = POD_SESSIONS[id.to_s]
+    return unless session
+
+    Process.kill("TERM", session[:pid]) rescue nil
+    POD_SESSIONS.delete(id.to_s)
+  end
+
+  private
+
+  def terminal_binary
+    "kubectl"
+  end
 
   def self.display_name(number = 1)
     n_('Pod (Kubernetes)', 'Pods (Kubernetes)', number)

--- a/app/models/manageiq/providers/kubernetes/container_manager/container_group.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_group.rb
@@ -1,55 +1,11 @@
-require "pty"
-
 class ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup < ContainerGroup
+  include RemoteConsole
+
   alias_attribute :pod_uid, :ems_ref
 
   supports :capture
 
-  def raw_start_terminal_session
-    opts = ext_management_system.connect_options
-
-    pty_out, pty_in, pid = PTY.spawn(
-      terminal_binary, "exec", "-it", name,
-      "-n", container_project.name,
-      "-c", containers.first.name,
-      "--server=https://#{opts[:hostname]}:#{opts[:port]}",
-      "--token=#{opts[:bearer]}",
-      "--insecure-skip-tls-verify",
-      "--", "/bin/sh"
-    )
-
-    {:pty_in => pty_in, :pty_out => pty_out, :pid => pid}
-  end
-
-  def raw_send_terminal_input(data)
-    session = POD_SESSIONS[id.to_s]
-    return unless session
-
-    session[:pty_in].write(data)
-    session[:pty_in].flush
-  end
-
-  def raw_stop_terminal_session
-    session = POD_SESSIONS[id.to_s]
-    return unless session
-
-    begin
-      Process.kill("TERM", session[:pid])
-    rescue
-      nil
-    end
-    POD_SESSIONS.delete(id.to_s)
-  end
-
-  private
-
-  def terminal_binary
-    "kubectl"
-  end
-
   def self.display_name(number = 1)
     n_('Pod (Kubernetes)', 'Pods (Kubernetes)', number)
   end
-
-  private_class_method :display_name
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/container_group.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_group.rb
@@ -1,6 +1,6 @@
 require "pty"
 
-class ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup < ::ContainerGroup
+class ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup < ContainerGroup
   alias_attribute :pod_uid, :ems_ref
 
   supports :capture
@@ -18,7 +18,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup < ::Cont
       "--", "/bin/sh"
     )
 
-    { :pty_in => pty_in, :pty_out => pty_out, :pid => pid }
+    {:pty_in => pty_in, :pty_out => pty_out, :pid => pid}
   end
 
   def raw_send_terminal_input(data)
@@ -33,7 +33,11 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup < ::Cont
     session = POD_SESSIONS[id.to_s]
     return unless session
 
-    Process.kill("TERM", session[:pid]) rescue nil
+    begin
+      Process.kill("TERM", session[:pid])
+    rescue
+      nil
+    end
     POD_SESSIONS.delete(id.to_s)
   end
 
@@ -46,4 +50,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup < ::Cont
   def self.display_name(number = 1)
     n_('Pod (Kubernetes)', 'Pods (Kubernetes)', number)
   end
+
+  private_class_method :display_name
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/container_group/remote_console.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_group/remote_console.rb
@@ -1,0 +1,60 @@
+module ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup::RemoteConsole
+  def console_supported?(type)
+    %w[KUBE_EXEC].include?(type.upcase)
+  end
+
+  def validate_remote_console_acquire_ticket(protocol, _options = {})
+    if ext_management_system.nil?
+      raise(MiqException::RemoteConsoleNotSupportedError,
+            "#{protocol} remote console requires the pod to be registered with a management system.")
+    end
+
+    unless phase == "Running"
+      raise(MiqException::RemoteConsoleNotSupportedError,
+            "#{protocol} remote console requires the pod to be running.")
+    end
+  end
+
+  def remote_console_acquire_ticket(userid, originating_server, protocol)
+    send("remote_console_#{protocol.to_s.downcase}_acquire_ticket", userid, originating_server)
+  end
+
+  def remote_console_acquire_ticket_queue(protocol, userid)
+    task_opts = {
+      :action => "acquiring Pod #{name} #{protocol.to_s.upcase} remote console ticket for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :instance_id => id,
+      :method_name => 'remote_console_acquire_ticket',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => [userid, MiqServer.my_server.id, protocol]
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def remote_console_kube_exec_acquire_ticket(userid, originating_server = nil)
+    validate_remote_console_acquire_ticket("kube_exec")
+
+    SystemConsole.force_vm_invalid_token(id)
+
+    api_uri = ext_management_system.api_endpoint
+
+    console_args = {
+      :user               => User.find_by(:userid => userid),
+      :container_group_id => id,
+      :ssl                => true,
+      :protocol           => 'kube_exec',
+      :secret             => SecureRandom.hex,
+      :url_secret         => SecureRandom.hex
+    }
+
+    SystemConsole.launch_proxy_if_not_local(console_args, originating_server, api_uri.host, api_uri.port)
+  end
+end

--- a/app/models/manageiq/providers/kubernetes/container_manager/container_group/remote_console.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_group/remote_console.rb
@@ -15,11 +15,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup::Remote
     end
   end
 
-  def remote_console_acquire_ticket(userid, originating_server, protocol)
-    send("remote_console_#{protocol.to_s.downcase}_acquire_ticket", userid, originating_server)
+  def remote_console_acquire_ticket(userid, originating_server, protocol, container_id = nil)
+    send("remote_console_#{protocol.to_s.downcase}_acquire_ticket", userid, originating_server, container_id)
   end
 
-  def remote_console_acquire_ticket_queue(protocol, userid)
+  def remote_console_acquire_ticket_queue(protocol, userid, container_id = nil)
     task_opts = {
       :action => "acquiring Pod #{name} #{protocol.to_s.upcase} remote console ticket for user #{userid}",
       :userid => userid
@@ -33,26 +33,27 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup::Remote
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
       :zone        => my_zone,
-      :args        => [userid, MiqServer.my_server.id, protocol]
+      :args        => [userid, MiqServer.my_server.id, protocol, container_id]
     }
 
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
-  def remote_console_kube_exec_acquire_ticket(userid, originating_server = nil)
+  def remote_console_kube_exec_acquire_ticket(userid, originating_server = nil, container_id = nil)
     validate_remote_console_acquire_ticket("kube_exec")
 
     SystemConsole.force_vm_invalid_token(id)
 
     api_uri = ext_management_system.api_endpoint
+    container_id ||= containers.first&.id
 
     console_args = {
-      :user               => User.find_by(:userid => userid),
-      :container_group_id => id,
-      :ssl                => true,
-      :protocol           => 'kube_exec',
-      :secret             => SecureRandom.hex,
-      :url_secret         => SecureRandom.hex
+      :user         => User.find_by(:userid => userid),
+      :container_id => container_id,
+      :ssl          => true,
+      :protocol     => 'kube_exec',
+      :secret       => SecureRandom.hex,
+      :url_secret   => SecureRandom.hex
     }
 
     SystemConsole.launch_proxy_if_not_local(console_args, originating_server, api_uri.host, api_uri.port)

--- a/app/models/manageiq/providers/kubernetes/container_manager/container_group/remote_console.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_group/remote_console.rb
@@ -5,13 +5,13 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup::Remote
 
   def validate_remote_console_acquire_ticket(protocol, _options = {})
     if ext_management_system.nil?
-      raise(MiqException::RemoteConsoleNotSupportedError,
-            "#{protocol} remote console requires the pod to be registered with a management system.")
+      raise MiqException::RemoteConsoleNotSupportedError,
+        "#{protocol} remote console requires the pod to be registered with a management system."
     end
 
     unless phase == "Running"
-      raise(MiqException::RemoteConsoleNotSupportedError,
-            "#{protocol} remote console requires the pod to be running.")
+      raise MiqException::RemoteConsoleNotSupportedError,
+        "#{protocol} remote console requires the pod to be running."
     end
   end
 


### PR DESCRIPTION
Implements `raw_start_terminal_session`, `raw_send_terminal_input`, and `raw_stop_terminal_session` on `ContainerGroup` using PTY + `kubectl exec`.

Part of the pod terminal feature https://github.com/ManageIQ/manageiq/pull/23895.