### PR TITLE
Add Pod Logs feature

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/container_group.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_group.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup < ::ContainerGroup
+  include Logs
+
   alias_attribute :pod_uid, :ems_ref
 
   supports :capture

--- a/app/models/manageiq/providers/kubernetes/container_manager/container_group/logs.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/container_group/logs.rb
@@ -1,0 +1,14 @@
+module ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup::Logs
+  def logs(container_name, options = {})
+    params = {:container => container_name}.merge(options)
+
+    ext_management_system
+      .connect(:service => "kubernetes")
+      .get_pod_log(
+        name,
+        container_project.name,
+        **params
+      )
+      .body
+  end
+end


### PR DESCRIPTION
## Purpose

Implement provider-specific support for retrieving pod logs from Kubernetes/OpenShift clusters.

## Changes

- Add pod log retrieval methods
- Used Kubeclient API to fetch logs

## Testing

Verified logs are retrieved from a running pod in a Kubernetes/OpenShift cluster.

Depends on:
- https://github.com/ManageIQ/manageiq-ui-classic/pull/10201
- https://github.com/ManageIQ/manageiq/pull/23942 
- https://github.com/ManageIQ/manageiq-api/pull/1339